### PR TITLE
Document the use of SMTs to customize _id field

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "performance/resources/.+\\.ipynb|src/test/resources/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-07-19T15:16:34Z",
+  "generated_at": "2022-07-20T15:13:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -97,7 +97,7 @@
       {
         "hashed_secret": "333f0f8814d63e7268f80e1e65e7549137d2350c",
         "is_verified": false,
-        "line_number": 229,
+        "line_number": 225,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "performance/resources/.+\\.ipynb|src/test/resources/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-06-27T22:56:13Z",
+  "generated_at": "2022-07-19T00:48:03Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -97,7 +97,7 @@
       {
         "hashed_secret": "333f0f8814d63e7268f80e1e65e7549137d2350c",
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 206,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -106,7 +106,7 @@
       {
         "hashed_secret": "b48edfdb054b3af80a24bbb8e0666a0dada90c3e",
         "is_verified": false,
-        "line_number": 217,
+        "line_number": 218,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "performance/resources/.+\\.ipynb|src/test/resources/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-07-19T00:48:03Z",
+  "generated_at": "2022-07-19T00:51:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -97,7 +97,7 @@
       {
         "hashed_secret": "333f0f8814d63e7268f80e1e65e7549137d2350c",
         "is_verified": false,
-        "line_number": 206,
+        "line_number": 223,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "performance/resources/.+\\.ipynb|src/test/resources/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-06-15T15:41:43Z",
+  "generated_at": "2022-06-17T15:45:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -97,7 +97,7 @@
       {
         "hashed_secret": "333f0f8814d63e7268f80e1e65e7549137d2350c",
         "is_verified": false,
-        "line_number": 168,
+        "line_number": 195,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "performance/resources/.+\\.ipynb|src/test/resources/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-07-19T00:51:14Z",
+  "generated_at": "2022-07-19T15:16:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -97,7 +97,7 @@
       {
         "hashed_secret": "333f0f8814d63e7268f80e1e65e7549137d2350c",
         "is_verified": false,
-        "line_number": 223,
+        "line_number": 229,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "performance/resources/.+\\.ipynb|src/test/resources/.+\\.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-06-17T15:45:42Z",
+  "generated_at": "2022-06-27T22:56:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -97,7 +97,7 @@
       {
         "hashed_secret": "333f0f8814d63e7268f80e1e65e7549137d2350c",
         "is_verified": false,
-        "line_number": 195,
+        "line_number": 196,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Example configuration:
     ```
     See the [Kafka Connect transforms](https://kafka.apache.org/31/documentation.html#connect_transforms) documentation for more details.
 
+**Note:** For each message record that the sink connector writes to Cloudant the document ID from this priority order:
+
+1. From the value of the `cloudant_doc_id` header on the message.  The value passed to this header must be a string and the `header.converter=org.apache.kafka.connect.storage.StringConverter` config is required.  This will overwrite the `_id` field if it already exists.
+1. The value of the `_id` field in the JSON
+1. If no other non-null or non-empty value is available the document will be created with a new UUID.
+
 #### Single Message Transforms
 
 Single Message Transforms, or SMTs, can be used to customize fields or values of messages during data flow.  The examples below will explore modifying fields for messages flowing from the Kafka topic to a Cloudant database using the sink connector.
@@ -90,16 +96,16 @@ you'll need to use a `dropNullRecords` transform and predicate to filter out and
     predicates.isNullRecord.type=org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
     ```
 
-5. If you want to use the message key or another custom value as the document ID then use the `CLOUDANT_PREFERRED_ID` custom header.
+5. If you want to use the message key or another custom value as the document ID then use the `cloudant_doc_id` custom header.
    The value set in this custom header will be added to the `_id` field.  If the `_id` field already exists then it will be overwritten
    with the value in this header.
    You can use the `HeaderFrom` SMT to move or copy a key to the custom header. The example config below adds the transform to move 
-   the `docid` record key to the `CLOUDANT_PREFERRED_ID` custom header and sets the header converter to string:
+   the `docid` record key to the `cloudant_doc_id` custom header and sets the header converter to string:
    ```
    transforms=moveFieldsToHeaders
    transforms.moveFieldsToHeaders.type=org.apache.kafka.connect.transforms.HeaderFrom$Key
    transforms.moveFieldsToHeaders.fields=docid
-   transforms.moveFieldsToHeaders.headers=CLOUDANT_PREFERRED_ID
+   transforms.moveFieldsToHeaders.headers=cloudant_doc_id
    transforms.moveFieldsToHeaders.operation=move
    
    header.converter=org.apache.kafka.connect.storage.StringConverter

--- a/README.md
+++ b/README.md
@@ -70,22 +70,14 @@ Single Message Transforms, or SMTs, can be used to customize fields or values of
     transforms.RenameField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
     transforms.RenameField.renames=name:_id
     ```
-2. If you have `_id` fields and would prefer to have Cloudant generate a UUID for the document ID, use the `ReplaceField` transform to exclude the existing `_id` field:
+1. If you have `_id` fields and would prefer to have Cloudant generate a UUID for the document ID, use the `ReplaceField` transform to exclude the existing `_id` field:
     ```
     transforms=ReplaceField
     transforms.ReplaceField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
     transforms.ReplaceField.exclude=_id
     ```
-3. If you have messages where the `_id` field is absent or `null` then Cloudant will generate
-a document ID. If you don't want this to happen then set an `_id` (see earlier examples).
-Alternatively filter out those documents. For example if you have messages where the `_id`
-field is `null` then you'll need to use a transform and predicate to filter out and remove this
-field:
-    ```
-    TODO 
-    ```
 
-4. If you have records where there is no value e.g. tombstones (and don't want the Cloudant sink connector to generate an empty doc with a generated ID) then 
+1. If you have records where there is no value e.g. tombstones (and don't want the Cloudant sink connector to generate an empty doc with a generated ID) then 
 you'll need to use a `dropNullRecords` transform and predicate to filter out and remove these tombstone records:  
     ```
     transforms=dropNullRecords
@@ -96,7 +88,7 @@ you'll need to use a `dropNullRecords` transform and predicate to filter out and
     predicates.isNullRecord.type=org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
     ```
 
-5. If you want to use the message key or another custom value as the document ID then use the `cloudant_doc_id` custom header.
+1. If you want to use the message key or another custom value as the document ID then use the `cloudant_doc_id` custom header.
    The value set in this custom header will be added to the `_id` field.  If the `_id` field already exists then it will be overwritten
    with the value in this header.
    You can use the `HeaderFrom` SMT to move or copy a key to the custom header. The example config below adds the transform to move 
@@ -113,7 +105,11 @@ you'll need to use a `dropNullRecords` transform and predicate to filter out and
 
    **Note**: The `header.converter` is required to be set to `StringConverter` since the document ID field only supports strings.
 
-**Note**: For any of the SMTs above, if the field does not exist it will skip over that message and continue processing the next message.
+1. If you have messages where the `_id` field is absent or `null` then Cloudant will generate
+a document ID. If you don't want this to happen then set an `_id` (see earlier examples).
+If you need to filter out those documents or drop `_id` fields when the value is `null` then you'll need to create a custom SMT.
+
+**Note**: For any of the SMTs above, if the field does not exist it will leave the message unmodified and continue processing the next message.
 
 ### Authentication
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Example configuration:
     ```
     See the [Kafka Connect transforms](https://kafka.apache.org/31/documentation.html#connect_transforms) documentation for more details.
 
-#### Rename, replace, or drop fields using Single Message Transforms
+#### Single Message Transforms
 
 Single Message Transforms, or SMTs, can be used to customize fields or values of messages during data flow.  The examples below will explore modifying fields for messages flowing from the Kafka topic to a Cloudant database using the sink connector.
 
@@ -64,14 +64,23 @@ Single Message Transforms, or SMTs, can be used to customize fields or values of
     transforms.RenameField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
     transforms.RenameField.renames=name:_id
     ```
-1. If you have `_id` fields and would prefer to have Cloudant generate a UUID for the document ID, use the `ReplaceField` transform to exclude the existing `_id` field:
+2. If you have `_id` fields and would prefer to have Cloudant generate a UUID for the document ID, use the `ReplaceField` transform to exclude the existing `_id` field:
     ```
     transforms=ReplaceField
     transforms.ReplaceField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
     transforms.ReplaceField.exclude=_id
     ```
-1. If you have messages where the `_id` field is absent or `null` then Cloudant will generate a document ID.  If you don't want this to happen then set an `_id` (see earlier examples) or filter out those documents.
-If you have messages where the `_id` field is `null` then you'll need to use a transform and predicate to filter out and remove this field:
+3. If you have messages where the `_id` field is absent or `null` then Cloudant will generate
+a document ID. If you don't want this to happen then set an `_id` (see earlier examples).
+Alternatively filter out those documents. For example if you have messages where the `_id`
+field is `null` then you'll need to use a transform and predicate to filter out and remove this
+field:
+    ```
+    TODO 
+    ```
+
+4. If you have records where there is no value e.g. tombstones (and don't want the Cloudant sink connector to generate an empty doc with a generated ID) then 
+you'll need to use a `dropNullRecords` transform and predicate to filter out and remove these tombstone records:  
     ```
     transforms=dropNullRecords
     transforms.dropNullRecords.type=org.apache.kafka.connect.transforms.Filter
@@ -80,6 +89,7 @@ If you have messages where the `_id` field is `null` then you'll need to use a t
     predicates=isNullRecord
     predicates.isNullRecord.type=org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
     ```
+
 **Note**: For any of the SMTs above, if the field does not exist it will skip over that message and continue processing the next message.
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ Single Message Transforms, or SMTs, can be used to customize fields or values of
     transforms.RenameField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
     transforms.RenameField.renames=name:_id
     ```
-1. If you would prefer to have Cloudant generate a UUID for the document ID, use the `ReplaceField` transform to exclude the existing `_id` field:
+1. If you have `_id` fields and would prefer to have Cloudant generate a UUID for the document ID, use the `ReplaceField` transform to exclude the existing `_id` field:
     ```
     transforms=ReplaceField
     transforms.ReplaceField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
     transforms.ReplaceField.exclude=_id
     ```
-1. If you have messages where the `_id` field is `null` then you'll need to use a transform and predicate to filter out and remove this field:
+1. If you have messages where the `_id` field is absent or `null` then Cloudant will generate a document ID.  If you don't want this to happen then set an `_id` (see earlier examples) or filter out those documents.
+If you have messages where the `_id` field is `null` then you'll need to use a transform and predicate to filter out and remove this field:
     ```
     transforms=dropNullRecords
     transforms.dropNullRecords.type=org.apache.kafka.connect.transforms.Filter

--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ Example configuration:
     ```
     See the [Kafka Connect transforms](https://kafka.apache.org/31/documentation.html#connect_transforms) documentation for more details.
 
+#### Rename, replace, or drop fields using Single Message Transforms
+
+Single Message Transforms, or SMTs, can be used to customize fields or values of messages during data flow.  The examples below will explore modifying fields for messages flowing from the Kafka topic to a Cloudant database using the sink connector.
+
+1. If there's an existing field that will be used as the document ID then use the `ReplaceField` transform.  See the config example below that renames `name` to `_id` field:
+    ```
+    transforms=RenameField
+    transforms.RenameField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
+    transforms.RenameField.renames=name:_id
+    ```
+1. If you would prefer to have Cloudant generate a UUID for the document ID, use the `ReplaceField` transform to exclude the existing `_id` field:
+    ```
+    transforms=ReplaceField
+    transforms.ReplaceField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
+    transforms.ReplaceField.exclude=_id
+    ```
+1. If you have messages where the `_id` field is `null` then you'll need to use a transform and predicate to filter out and remove this field:
+    ```
+    transforms=dropNullRecords
+    transforms.dropNullRecords.type=org.apache.kafka.connect.transforms.Filter
+    transforms.dropNullRecords.predicate=isNullRecord
+
+    predicates=isNullRecord
+    predicates.isNullRecord.type=org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
+    ```
+**Note**: For any of the SMTs above, if the field does not exist it will skip over that message and continue processing the next message.
+
 ### Authentication
 
 In order to read from or write to Cloudant, some authentication properties need to be configured. These properties are common to both the source and sink connector.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ you'll need to use a `dropNullRecords` transform and predicate to filter out and
     predicates.isNullRecord.type=org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
     ```
 
+5. If you want to use the message key or another custom value as the document ID then use the `CLOUDANT_PREFERRED_ID` custom header.
+   The value set in this custom header will be added to the `_id` field.  If the `_id` field already exists then it will be overwritten
+   with the value in this header.
+   You can use the `HeaderFrom` SMT to move or copy a key to the custom header. The example config below adds the transform to move 
+   the `docid` record key to the `CLOUDANT_PREFERRED_ID` custom header and sets the header converter to string:
+   ```
+   transforms=moveFieldsToHeaders
+   transforms.moveFieldsToHeaders.type=org.apache.kafka.connect.transforms.HeaderFrom$Key
+   transforms.moveFieldsToHeaders.fields=docid
+   transforms.moveFieldsToHeaders.headers=CLOUDANT_PREFERRED_ID
+   transforms.moveFieldsToHeaders.operation=move
+   
+   header.converter=org.apache.kafka.connect.storage.StringConverter
+   ```
+
+   **Note**: The `header.converter` is required to be set to `StringConverter` since the document ID field only supports strings.
+
 **Note**: For any of the SMTs above, if the field does not exist it will skip over that message and continue processing the next message.
 
 ### Authentication

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Example configuration:
 
 Single Message Transforms, or SMTs, can be used to customize fields or values of events during data flow.  The examples below will explore modifying fields for events flowing from the Kafka topic to a Cloudant database using the sink connector.
 
-1. If the record value contains an existing field, not called `_id`, that is suitable to use as the Cloudant document ID, then you can use the `RenameField` transform.
+1. If the event value contains an existing field, not called `_id`, that is suitable to use as the Cloudant document ID, then you can use the `RenameField` transform.
     ```
     transforms=RenameField
     transforms.RenameField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For the sink connector:
 1. Kafka keys are currently ignored; therefore the key converter settings are not relevant.
 1. We assume that the values in kafka are serialized JSON objects, and therefore `JsonConverter` is supported. If your values contain a schema (`{"schema": {...}, "payload": {...}}`), then set `value.converter.schemas.enable=true`, otherwise set `value.converter.schemas.enable=false`. Any other converter that converts the message values into `org.apache.kafka.connect.data.Struct` or `java.util.Map` types should also work. However, it must be noted that the subsequent serialization of `Map` or `Struct` values to JSON documents in the sink may not match expectations if a schema has not been provided.
 1. Inserting only a single revision of any `_id` is currently supported.  This means it cannot update or delete documents.
-1. The `_rev` field in message values are preserved.  To remove `rev` during data flow, use the `ReplaceField` Single Message Transforms (SMT).
+1. The `_rev` field in event values are preserved.  To remove `rev` during data flow, use the `ReplaceField` Single Message Transforms (SMT).
 Example configuration:
     ```
     transforms=ReplaceField
@@ -54,17 +54,17 @@ Example configuration:
     ```
     See the [Kafka Connect transforms](https://kafka.apache.org/31/documentation.html#connect_transforms) documentation for more details.
 
-**Note:** For each message record that the sink connector writes to Cloudant the document ID from this priority order:
+**Note:** The ID of each document written to Cloudant by the sink connector can be configured as follows:
 
-1. From the value of the `cloudant_doc_id` header on the message.  The value passed to this header must be a string and the `header.converter=org.apache.kafka.connect.storage.StringConverter` config is required.  This will overwrite the `_id` field if it already exists.
+1. From the value of the `cloudant_doc_id` header on the event.  The value passed to this header must be a string and the `header.converter=org.apache.kafka.connect.storage.StringConverter` config is required.  This will overwrite the `_id` field if it already exists.
 1. The value of the `_id` field in the JSON
 1. If no other non-null or non-empty value is available the document will be created with a new UUID.
 
 #### Single Message Transforms
 
-Single Message Transforms, or SMTs, can be used to customize fields or values of messages during data flow.  The examples below will explore modifying fields for messages flowing from the Kafka topic to a Cloudant database using the sink connector.
+Single Message Transforms, or SMTs, can be used to customize fields or values of events during data flow.  The examples below will explore modifying fields for events flowing from the Kafka topic to a Cloudant database using the sink connector.
 
-1. If there's an existing field that will be used as the document ID then use the `ReplaceField` transform.  See the config example below that renames `name` to `_id` field:
+1. If the record value contains an existing field, not called `_id`, that is suitable to use as the Cloudant document ID, then you can use the `RenameField` transform.
     ```
     transforms=RenameField
     transforms.RenameField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
@@ -77,8 +77,8 @@ Single Message Transforms, or SMTs, can be used to customize fields or values of
     transforms.ReplaceField.exclude=_id
     ```
 
-1. If you have records where there is no value e.g. tombstones (and don't want the Cloudant sink connector to generate an empty doc with a generated ID) then 
-you'll need to use a `dropNullRecords` transform and predicate to filter out and remove these tombstone records:  
+1. If you have events where there is no value e.g. tombstones (and don't want the Cloudant sink connector to generate an empty doc with a generated ID) then 
+you'll need to use a `dropNullRecords` transform and predicate to filter out and remove these tombstone events:  
     ```
     transforms=dropNullRecords
     transforms.dropNullRecords.type=org.apache.kafka.connect.transforms.Filter
@@ -88,11 +88,11 @@ you'll need to use a `dropNullRecords` transform and predicate to filter out and
     predicates.isNullRecord.type=org.apache.kafka.connect.transforms.predicates.RecordIsTombstone
     ```
 
-1. If you want to use the message key or another custom value as the document ID then use the `cloudant_doc_id` custom header.
+1. If you want to use the event key or another custom value as the document ID then use the `cloudant_doc_id` custom header.
    The value set in this custom header will be added to the `_id` field.  If the `_id` field already exists then it will be overwritten
    with the value in this header.
    You can use the `HeaderFrom` SMT to move or copy a key to the custom header. The example config below adds the transform to move 
-   the `docid` record key to the `cloudant_doc_id` custom header and sets the header converter to string:
+   the `docid` event key to the `cloudant_doc_id` custom header and sets the header converter to string:
    ```
    transforms=moveFieldsToHeaders
    transforms.moveFieldsToHeaders.type=org.apache.kafka.connect.transforms.HeaderFrom$Key
@@ -105,11 +105,11 @@ you'll need to use a `dropNullRecords` transform and predicate to filter out and
 
    **Note**: The `header.converter` is required to be set to `StringConverter` since the document ID field only supports strings.
 
-1. If you have messages where the `_id` field is absent or `null` then Cloudant will generate
+1. If you have events where the `_id` field is absent or `null` then Cloudant will generate
 a document ID. If you don't want this to happen then set an `_id` (see earlier examples).
 If you need to filter out those documents or drop `_id` fields when the value is `null` then you'll need to create a custom SMT.
 
-**Note**: For any of the SMTs above, if the field does not exist it will leave the message unmodified and continue processing the next message.
+**Note**: For any of the SMTs above, if the field does not exist it will leave the event unmodified and continue processing the next event.
 
 ### Authentication
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation group: 'org.json', name: 'json', version: '20210307'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
     implementation group: 'org.apache.kafka', name: 'connect-api', version: "${kafkaVersion}"
+    implementation group: 'org.apache.kafka', name: 'connect-transforms', version: "${kafkaVersion}"
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.powermock', name: 'powermock-api-easymock', version: '1.6.4'
     testImplementation group: 'org.easymock', name: 'easymock', version: '3.4'

--- a/src/main/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapper.java
+++ b/src/main/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapper.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 
 public class ConnectRecordMapper<R extends ConnectRecord<R>> implements Function<ConnectRecord<R>, Map<String, Object>> {
 
-    public static final String HEADER_DOC_ID_KEY = "cloudant_doc_id";
+    static final String HEADER_DOC_ID_KEY = "cloudant_doc_id";
     
     private static Logger LOG = LoggerFactory.getLogger(ConnectRecordMapper.class);
 
@@ -125,7 +125,7 @@ public class ConnectRecordMapper<R extends ConnectRecord<R>> implements Function
     }
 
     private String getHeaderForDocId(ConnectRecord<R> record) {
-        Header value = record.headers().lastWithName("cloudant_doc_id");
+        Header value = record.headers().lastWithName(HEADER_DOC_ID_KEY);
         if (value != null && value.value() instanceof String) {
             return value.value().toString();
         }

--- a/src/main/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapper.java
+++ b/src/main/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapper.java
@@ -27,12 +27,12 @@ import java.util.Map;
 import java.util.function.Function;
 
 public class ConnectRecordMapper<R extends ConnectRecord<R>> implements Function<ConnectRecord<R>, Map<String, Object>> {
+
+    public static final String HEADER_DOC_ID_KEY = "cloudant_doc_id";
     
     private static Logger LOG = LoggerFactory.getLogger(ConnectRecordMapper.class);
 
     public Map<String, Object> apply(ConnectRecord<R> record) {
-        // Check if custom header exists on the record and use the value for the document's id
-        String headerValue = getHeaderForDocId(record);
         // we can convert from a struct or a map - assume a map when a value schema is not provided
         Schema.Type schemaType = record.valueSchema() == null ? Schema.Type.MAP : record.valueSchema().type();
         Map<String, Object> toReturn = new HashMap<>();
@@ -56,7 +56,9 @@ public class ConnectRecordMapper<R extends ConnectRecord<R>> implements Function
             default:
                 throw new IllegalArgumentException(String.format("Schema type %s not supported", record.valueSchema().type()));
         }
-        if (!toReturn.isEmpty() && headerValue != null) {
+        // Check if custom header exists on the record and use the value for the document's id
+        String headerValue = getHeaderForDocId(record);
+        if (!toReturn.isEmpty() && headerValue != null && !headerValue.isEmpty()) {
             toReturn.put("_id", headerValue);
         }
         return toReturn;

--- a/src/main/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapper.java
+++ b/src/main/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapper.java
@@ -39,26 +39,16 @@ public class ConnectRecordMapper<R extends ConnectRecord<R>> implements Function
         switch (schemaType) {
             case MAP:
                 if (record.value() instanceof Map) {
-                    if (headerValue != null) {
-                        convertMap((Map) record.value(), toReturn);
-                        toReturn.put("_id", headerValue);
-                        return toReturn;
-                    } else {
-                        return convertMap((Map) record.value(), toReturn);
-                    }
+                    convertMap((Map) record.value(), toReturn);
+                    break;
                 } else {
                     throw new IllegalArgumentException(String.format("Type %s not supported with schema of type Map (or no schema)",
                             record.value().getClass()));
                 }
             case STRUCT:
                 if (record.value() instanceof Struct) {
-                    if (headerValue != null) {
-                        convertStruct((Struct) record.value(), toReturn);
-                        toReturn.put("_id", headerValue);
-                        return toReturn;
-                    } else {
-                        return convertStruct((Struct) record.value(), toReturn);
-                    }
+                    convertStruct((Struct) record.value(), toReturn);
+                    break;
                 } else {
                     throw new IllegalArgumentException(String.format("Type %s not supported with schema of type Struct",
                             record.value().getClass()));
@@ -66,6 +56,10 @@ public class ConnectRecordMapper<R extends ConnectRecord<R>> implements Function
             default:
                 throw new IllegalArgumentException(String.format("Schema type %s not supported", record.valueSchema().type()));
         }
+        if (!toReturn.isEmpty() && headerValue != null) {
+            toReturn.put("_id", headerValue);
+        }
+        return toReturn;
     }
 
     // convert struct to map by adding key/values to passed in map, and returning it 
@@ -129,7 +123,7 @@ public class ConnectRecordMapper<R extends ConnectRecord<R>> implements Function
     }
 
     private String getHeaderForDocId(ConnectRecord<R> record) {
-        Header value = record.headers().lastWithName("CLOUDANT_PREFERRED_ID");
+        Header value = record.headers().lastWithName("cloudant_doc_id");
         if (value != null && value.value() instanceof String) {
             return value.value().toString();
         }

--- a/src/test/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapperTests.java
+++ b/src/test/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapperTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.ibm.cloudant.kafka.schema.ConnectRecordMapper.HEADER_DOC_ID_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -31,8 +32,6 @@ public class ConnectRecordMapperTests {
 
     // for these tests we will operate on SinkRecords, but they could just as easily be SourceRecords - for our purposes they are equivalent
     ConnectRecordMapper<SinkRecord> mapper = new ConnectRecordMapper<>();
-    
-    String headerKey = "cloudant_doc_id";
 
     @Test
     public void testConvertToMapSchema() {
@@ -68,7 +67,7 @@ public class ConnectRecordMapperTests {
         Map<String, String> value = new HashMap<>();
         value.put("hello", "world");
         SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
-        sr.headers().addString(headerKey, headerValue);
+        sr.headers().addString(HEADER_DOC_ID_KEY, headerValue);
         // when...
         Map<String, Object> converted = mapper.apply(sr);
         // then...
@@ -164,7 +163,7 @@ public class ConnectRecordMapperTests {
 
         // do conversion
         SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
-        sr.headers().addString(headerKey, headerValue);
+        sr.headers().addString(HEADER_DOC_ID_KEY, headerValue);
         Map<String, Object> converted = mapper.apply(sr);
 
         // then...
@@ -192,7 +191,7 @@ public class ConnectRecordMapperTests {
 
         // do conversion
         SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
-        sr.headers().addString(headerKey, headerValue);
+        sr.headers().addString(HEADER_DOC_ID_KEY, headerValue);
         Map<String, Object> converted = mapper.apply(sr);
 
         // then...

--- a/src/test/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapperTests.java
+++ b/src/test/java/com/ibm/cloudant/kafka/schema/ConnectRecordMapperTests.java
@@ -31,6 +31,8 @@ public class ConnectRecordMapperTests {
 
     // for these tests we will operate on SinkRecords, but they could just as easily be SourceRecords - for our purposes they are equivalent
     ConnectRecordMapper<SinkRecord> mapper = new ConnectRecordMapper<>();
+    
+    String headerKey = "cloudant_doc_id";
 
     @Test
     public void testConvertToMapSchema() {
@@ -66,7 +68,7 @@ public class ConnectRecordMapperTests {
         Map<String, String> value = new HashMap<>();
         value.put("hello", "world");
         SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
-        sr.headers().addString("CLOUDANT_PREFERRED_ID", headerValue);
+        sr.headers().addString(headerKey, headerValue);
         // when...
         Map<String, Object> converted = mapper.apply(sr);
         // then...
@@ -162,7 +164,7 @@ public class ConnectRecordMapperTests {
 
         // do conversion
         SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
-        sr.headers().addString("CLOUDANT_PREFERRED_ID", headerValue);
+        sr.headers().addString(headerKey, headerValue);
         Map<String, Object> converted = mapper.apply(sr);
 
         // then...
@@ -190,7 +192,7 @@ public class ConnectRecordMapperTests {
 
         // do conversion
         SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
-        sr.headers().addString("CLOUDANT_PREFERRED_ID", headerValue);
+        sr.headers().addString(headerKey, headerValue);
         Map<String, Object> converted = mapper.apply(sr);
 
         // then...


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
fixes #65 
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
- Modify the ConnectRecordMapper to check for the presence of a custom header on the record and use the value of that header as the ID.
- Use the HeaderFrom transform to convert a key to the header, avoiding the need for us to have any custom SMT.
- Add README section for using SMTs to rename, replace, or filter out `_id` field.  Also document how to remove tombstone records.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
"No change"
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
"No change"
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
"No change"
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->

For reviewers:
- [This example](https://github.com/IBM/cloudant-kafka-connector/compare/65-sink-id-transform?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R80) requires a conditional SMT to drop the field if `_id == null`.  I need to re-review the SMT docs to see if we can filter on the value of fields.
- I've yet to successfully test the header to `_id` changes in a local Kafka environment.  In Kafka 3.2.0, they enabled the option to set headers when using `kafka-console-producer.sh`.  If you don't have 3.2.0 then you'll have to install and use `kcat`.
I'm using the example:
```
echo 'header:value\t{"test":"1", "try": 0, "time": true}'  | ./bin/kafka-console-producer.sh --topic kafka_test2 --bootstrap-server localhost:9092 --property "parse.headers=true" -
```
And this throws the error:
```
Caused by: org.apache.kafka.connect.errors.DataException: Only Map objects supported in absence of schema for [header move], found: null
	at org.apache.kafka.connect.transforms.util.Requirements.requireMap(Requirements.java:38)
	at org.apache.kafka.connect.transforms.HeaderFrom.applySchemaless(HeaderFrom.java:161)
	at org.apache.kafka.connect.transforms.HeaderFrom.apply(HeaderFrom.java:113)
	at org.apache.kafka.connect.runtime.TransformationChain.lambda$apply$0(TransformationChain.java:50)
	at org.apache.kafka.connect.runtime.TransformationChain$$Lambda$613/0x0000000000000000.call(Unknown Source)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:156)
	at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:190)
	... 14 more
```

