### PR TITLE
feat: Emit tombstones for deleted documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [BREAKING CHANGE] Source connector now emits tombstone events for deleted documents. See [single message transforms](README.md#single-message-transforms) section in README for details.
 - [BREAKING CHANGE] Publish releases to https://github.com/IBM/cloudant-kafka-connector/releases.
 - [BREAKING CHANGE] Rename package from `com.ibm.cloudant.kafka` to `com.ibm.cloud.cloudant.kafka`. Existing `connector.class` property values must be updated to use the new package.
 - [BREAKING CHANGE] Rename module from `kafka-connect-cloudant` to `cloudant-kafka-connector`.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ Single Message Transforms, or SMTs, can be used to customize fields or values of
     transforms.ReplaceField.type=org.apache.kafka.connect.transforms.ReplaceField$Value 
     transforms.ReplaceField.exclude=_id
     ```
+1. If you have events where there is no value ([_tombstone_ events](https://kafka.apache.org/documentation.html#compaction)), you may wish to filter these out.
+    - In the Cloudant sink connector, these may be undesirable as they will generate an empty document.
+    - In the Cloudant source connector, tombstone events are generated for deleted documents (in addition to the deleted document itself).
+    - In either case, you can use the `RecordIsTombstone` predicate with a filter to remove these tombstone events as shown in this example:
 
-1. If you have events where there is no value e.g. tombstones (and don't want the Cloudant sink connector to generate an empty doc with a generated ID) then 
-you'll need to use a `dropNullRecords` transform and predicate to filter out and remove these tombstone events:  
     ```
     transforms=dropNullRecords
     transforms.dropNullRecords.type=org.apache.kafka.connect.transforms.Filter

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSourceTask.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSourceTask.java
@@ -116,12 +116,21 @@ public class CloudantSourceTask extends SourceTask {
                             SourceRecord sourceRecord = new SourceRecord(offset(url, db),
                                     offsetValue(latestSequenceNumber),
                                     topic, // topics
-                                    //Integer.valueOf(row_.getId())%3, // partition
                                     Schema.STRING_SCHEMA, // key schema
                                     id, // key
                                     docSchema, // value schema
                                     docValue); // value
                             records.add(sourceRecord);
+                            if (doc.isDeleted() != null && doc.isDeleted()) {
+                                SourceRecord tombstone = new SourceRecord(offset(url, db),
+                                        offsetValue(latestSequenceNumber),
+                                        topic, // topics
+                                        Schema.STRING_SCHEMA, // key schema
+                                        id, // key
+                                        null, // value schema
+                                        null); // value
+                                records.add(tombstone);
+                            }
                         }
                     }
                 }

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/ClientManagerUtils.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/ClientManagerUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright © 2022 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.ibm.cloud.cloudant.kafka.connect;
 
 import com.ibm.cloud.cloudant.v1.Cloudant;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/ClientManagerUtils.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/ClientManagerUtils.java
@@ -1,0 +1,10 @@
+package com.ibm.cloud.cloudant.kafka.connect;
+
+import com.ibm.cloud.cloudant.v1.Cloudant;
+
+public class ClientManagerUtils {
+
+    public static void addClientToCache(String name, Cloudant cloudant) {
+        CachedClientManager.clientCache.put(name, cloudant);
+    }
+}

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/TombstoneTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/TombstoneTest.java
@@ -1,0 +1,100 @@
+package com.ibm.cloud.cloudant.kafka.connect;
+
+import com.ibm.cloud.cloudant.v1.Cloudant;
+import com.ibm.cloud.cloudant.v1.model.Change;
+import com.ibm.cloud.cloudant.v1.model.ChangesResult;
+import com.ibm.cloud.cloudant.v1.model.ChangesResultItem;
+import com.ibm.cloud.cloudant.v1.model.Document;
+import com.ibm.cloud.sdk.core.http.Response;
+import com.ibm.cloud.sdk.core.http.ServiceCall;
+import com.ibm.cloud.sdk.core.http.ServiceCallback;
+import io.reactivex.Single;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Assert;
+import org.junit.Test;
+import org.powermock.api.easymock.PowerMock;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+public class TombstoneTest {
+
+    private static final String connectionName = "_mock";
+
+    @Test
+    public void testDeletedDocumentEmitsTombstones() throws Exception{
+
+        String id = "123";
+
+        Document document = new Document();
+        document.setId(id);
+        document.setDeleted(Boolean.TRUE);
+
+        ChangesResultItem changesResultItem = PowerMock.createMock(ChangesResultItem.class);
+        Change change = PowerMock.createMock(Change.class);
+        Cloudant mockCloudant = PowerMock.createMock(Cloudant.class);
+        Response<ChangesResult> mockResponse = PowerMock.createMock(Response.class);
+        ChangesResult mockResult = PowerMock.createMock(ChangesResult.class);
+        expect(mockResponse.getResult()).andReturn(mockResult);
+        expect(mockResult.getResults()).andReturn(Collections.singletonList(changesResultItem));
+        expect(mockResult.getResults()).andReturn(Collections.singletonList(changesResultItem));
+        expect(mockResult.getLastSeq()).andReturn("100");
+        expect(changesResultItem.getChanges()).andReturn(Collections.singletonList(change));
+        expect(changesResultItem.getDoc()).andReturn(document);
+        expect(changesResultItem.getId()).andReturn(id);
+        expect(mockCloudant.postChanges(anyObject())).andReturn(new ServiceCall<ChangesResult>() {
+            @Override
+            public ServiceCall<ChangesResult> addHeader(String s, String s1) {
+                return null;
+            }
+
+            @Override
+            public Response<ChangesResult> execute() throws RuntimeException {
+                return mockResponse;
+            }
+
+            @Override
+            public void enqueue(ServiceCallback<ChangesResult> serviceCallback) {
+
+            }
+
+            @Override
+            public Single<Response<ChangesResult>> reactiveRequest() {
+                return null;
+            }
+
+            @Override
+            public void cancel() {
+
+            }
+        });
+        ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
+        CloudantSourceTask cloudantSourceTask = new CloudantSourceTask();
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("name", connectionName);
+        configMap.put("cloudant.since", "1000");
+        configMap.put("cloudant.url", "http://foo");
+        configMap.put("cloudant.db", "foo");
+        configMap.put("topics", "foo");
+        replay(mockCloudant);
+        replay(mockResponse);
+        replay(mockResult);
+        replay(change);
+        replay(changesResultItem);
+        cloudantSourceTask.start(configMap);
+        List<SourceRecord> records = cloudantSourceTask.poll();
+        Assert.assertEquals(2, records.size());
+        Assert.assertNotNull(records.get(0).value());
+        Assert.assertNull(records.get(1).value());
+        // TODO unpack record json and assert on it
+        Assert.assertEquals(id, records.get(0).key());
+        Assert.assertEquals(id, records.get(1).key());
+    }
+
+}


### PR DESCRIPTION
**Documentation**

Update README and CHANGES

**Testing**

Tested locally by deleting document from Cloudant and observing event with `./bin/kafka-console-consumer.sh  --bootstrap-server localhost:9092 --topic kafka_test --from-beginning --property print.key=true` 

```
{"schema":{"type":"string","optional":false},"payload":"f576db6ebceafaa4d585fa45bd8a3e1e"}	{
  "_deleted": true,
  "_id": "f576db6ebceafaa4d585fa45bd8a3e1e",
  "_rev": "2-30dc7747c854572ca4d0a2f8e6497ffb"
}
{"schema":{"type":"string","optional":false},"payload":"f576db6ebceafaa4d585fa45bd8a3e1e"}	null
```
