### PR TITLE
84 handle per event errors

### DIFF
--- a/src/main/java/com/ibm/cloud/cloudant/kafka/common/utils/JavaCloudantUtil.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/common/utils/JavaCloudantUtil.java
@@ -16,13 +16,8 @@ package com.ibm.cloud.cloudant.kafka.common.utils;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.ibm.cloud.cloudant.v1.model.*;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
-import com.ibm.cloud.cloudant.kafka.common.CloudantConst;
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
-import com.ibm.cloud.cloudant.kafka.common.MessageKey;
 import com.ibm.cloud.cloudant.kafka.connect.CachedClientManager;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,56 +56,25 @@ public class JavaCloudantUtil {
 		);
 	}
 
-	public static JSONArray batchWrite(Map<String, String> props, List<Map<String, Object>> data)
-		throws JSONException {
-		// wrap result to JSONArray
-		JSONArray result = new JSONArray();
-		JSONObject jsonResult = new JSONObject();
-		try {
-			Cloudant service = CachedClientManager.getInstance(props);
+	public static List<DocumentResult> batchWrite(Map<String, String> props, List<Map<String, Object>> data)
+		throws RuntimeException {
+		Cloudant service = CachedClientManager.getInstance(props);
 
-			List<Document> listOfDocs = data.stream().map(d -> {Document doc = new Document(); doc.setProperties(d); return doc; }).collect(Collectors.toList());
+		List<Document> listOfDocs = data.stream().map(d -> {Document doc = new Document(); doc.setProperties(d); return doc; }).collect(Collectors.toList());
 
-			// attempt to create database
-			createTargetDb(service, props.get(InterfaceConst.DB));
+		// attempt to create database
+		createTargetDb(service, props.get(InterfaceConst.DB));
 
-			//perform bulk insert for array of documents
-			BulkDocs docs = new BulkDocs.Builder().docs(listOfDocs).build();
-			PostBulkDocsOptions postBulkDocsOptions = new PostBulkDocsOptions.Builder()
-				.db(props.get(InterfaceConst.DB))
-				.bulkDocs(docs)
-				.build();
-			List<DocumentResult> resList = service.postBulkDocs(postBulkDocsOptions).execute().getResult();
+		// perform bulk insert for array of documents
+		BulkDocs docs = new BulkDocs.Builder().docs(listOfDocs).build();
+		PostBulkDocsOptions postBulkDocsOptions = new PostBulkDocsOptions.Builder()
+			.db(props.get(InterfaceConst.DB))
+			.bulkDocs(docs)
+			.build();
 
-			for(int j=0; j < resList.size();j++){
-				DocumentResult documentResult = resList.get(j);
-
-				// construct response which is similar to doPost()
-				// {"rev":"380-270e81b096fe9ed54dc42a14b47467b9","id":"kafka@database","ok":true}
-				jsonResult.put(CloudantConst.RESPONSE_ID,documentResult.getId());
-				jsonResult.put(CloudantConst.RESPONSE_REV,documentResult.getRev());
-				jsonResult.put(CloudantConst.RESPONSE_ERROR,documentResult.getError());
-				jsonResult.put(CloudantConst.RESPONSE_REASON,documentResult.getReason());
-				if (documentResult.getError() != null) {
-					jsonResult.put(CloudantConst.RESPONSE_OK,false);
-					// TODO support status code field in documentresult schema?
-					jsonResult.put(CloudantConst.RESPONSE_CODE, 400);
-				} else {
-					jsonResult.put(CloudantConst.RESPONSE_OK,true);
-					jsonResult.put(CloudantConst.RESPONSE_CODE, 201);
-				}
-
-				result.put(jsonResult);
-			}
-		} catch (Exception e) {
-			LOG.error("Exception caught in batchWrite()", e);
-			if(e.getMessage().equals(String.format(ResourceBundleUtil.get(
-				MessageKey.CLOUDANT_LIMITATION)))){
-				// try to put items from jsonResult before exception occurred
-				result.put(jsonResult);
-			}
-		}
-		return result;
+		// caller's responsibility to catch RuntimeException on execute() if thrown
+		List<DocumentResult> resList = service.postBulkDocs(postBulkDocsOptions).execute().getResult();
+		return resList;
 	}
 
 	public static void createTargetDb(Cloudant service, String dbName) {

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTask.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTask.java
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,6 +160,12 @@ public class CloudantSinkTask extends SinkTask {
 	@Override
 	public void close(Collection<TopicPartition> partitions) {
 		LOG.info("Committed ");
+	}
+
+	// for testing
+	// TODO find out if there is a better way to do this without changing production classes
+	public void setContext(SinkTaskContext ctx) {
+		this.context = ctx;
 	}
 
 }

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTask.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTask.java
@@ -121,7 +121,7 @@ public class CloudantSinkTask extends SinkTask {
 					LOG.info(String.format("Calling batchWrite with %d documents to %s", jsonSubArray.size(), config.getString(InterfaceConst.URL)));
 					List<DocumentResult> writeResults = JavaCloudantUtil.batchWrite(config.originalsStrings(), jsonSubArray);
 					boolean someFailed = writeResults.stream().anyMatch(doc -> doc.isOk() == null || !doc.isOk());
-					if (someFailed) {
+					if (reporter != null && someFailed) {
 						// logging not needed - user can enable `errors.log.enable` if required
 						for (int i = 0; i < writeResults.size(); i++) {
 							DocumentResult writeResult = writeResults.get(i);

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTask.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTask.java
@@ -29,7 +29,7 @@ import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -43,7 +43,7 @@ public class CloudantSinkTask extends SinkTask {
 	
 	List<String> topics = null;
 
-	public static int batch_size = 0;
+	public static int batchSize = 0;
 	private int taskNumber;
 	public static String guid_schema = null;
 	private Boolean replication;
@@ -61,18 +61,12 @@ public class CloudantSinkTask extends SinkTask {
 		 return new CloudantSinkConnector().version();
 	}
 
-	//TODO: all sinkRecords in first Thread
 	@Override
 	public void put(Collection<SinkRecord> sinkRecords) {
-
 		if (accumulatedSinkRecords == null) {
 			accumulatedSinkRecords = new LinkedList<>();
 		}
-
-		System.out.println(Arrays.toString(Thread.currentThread().getStackTrace()));
-
 		LOG.info("Thread[" + Thread.currentThread().getId() + "].sinkRecords = " + sinkRecords.size());
-
 		accumulatedSinkRecords.addAll(sinkRecords);
 	}
 
@@ -96,7 +90,7 @@ public class CloudantSinkTask extends SinkTask {
             //TODO: split topics from Connector
             topics = config.getList(InterfaceConst.TOPIC);
             
-            batch_size = config.getInt(InterfaceConst.BATCH_SIZE)==null ? InterfaceConst.DEFAULT_BATCH_SIZE : config.getInt(InterfaceConst.BATCH_SIZE);			
+            batchSize = config.getInt(InterfaceConst.BATCH_SIZE)==null ? InterfaceConst.DEFAULT_BATCH_SIZE : config.getInt(InterfaceConst.BATCH_SIZE);
 			replication = config.getBoolean(InterfaceConst.REPLICATION) == null ? InterfaceConst.DEFAULT_REPLICATION : config.getBoolean(InterfaceConst.REPLICATION); 
 		} catch (ConfigException e) {
 			throw new ConnectException(ResourceBundleUtil.get(MessageKey.CONFIGURATION_EXCEPTION), e);
@@ -106,11 +100,10 @@ public class CloudantSinkTask extends SinkTask {
 	@Override
 	public void flush(Map<TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> offsets) {
 
-		System.out.println(Arrays.toString(Thread.currentThread().getStackTrace()));
+		List<Map<String, Object>> jsonArray = new ArrayList<>();
 
-		List<Map<String, Object>> jsonArray = new LinkedList<>();
-
-		if (accumulatedSinkRecords != null) {
+		if (accumulatedSinkRecords != null && !accumulatedSinkRecords.isEmpty()) {
+			LOG.info(String.format("flush called with %d documents to %s", accumulatedSinkRecords.size(), config.getString(InterfaceConst.URL)));
 			// Note: _rev is preserved
 			accumulatedSinkRecords.stream()
 					.map(mapper) // Convert ConnectRecord to Map
@@ -118,38 +111,44 @@ public class CloudantSinkTask extends SinkTask {
 					.forEach(recordValueAsMap -> {
 						jsonArray.add(recordValueAsMap);
 					});
-		}
-
-
-		try {
-			LOG.info(String.format("Calling batchWrite with %d documents to %s", jsonArray.size(), config.getString(InterfaceConst.URL)));
-			List<DocumentResult> writeResults = JavaCloudantUtil.batchWrite(config.originalsStrings(), jsonArray);
-			boolean someFailed = writeResults.stream().anyMatch(doc -> doc.isOk() == null || !doc.isOk());
-			if (someFailed) {
-				LOG.error("Failed to write some documents");
-				for (int i=0; i<writeResults.size(); i++) {
-					// TODO - is checking isOk sufficient?
-					// TODO - are bulk doc results guaranteed to be in same order?
-					// TODO - think of a better exception to raise here
-					if (!writeResults.get(i).isOk()) {
-						reporter.report(accumulatedSinkRecords.get(i), new RuntimeException("not ok"));
+			try {
+				// break down accumulated records into batches to send to cloudant
+				// NB a failure in _any_ batch will currently cause all accumulated records to be marked as uncommitted
+				int nBatches = jsonArray.size() / batchSize + (jsonArray.size() % batchSize == 0 ? 0 : 1);
+				LOG.info(String.format("flush called with %d batches to %s", nBatches, config.getString(InterfaceConst.URL)));
+				for (int b = 0; b < nBatches; b++) {
+					List<Map<String, Object>> jsonSubArray = jsonArray.subList(b * batchSize, Math.min(jsonArray.size(), (b + 1) * batchSize));
+					LOG.info(String.format("Calling batchWrite with %d documents to %s", jsonSubArray.size(), config.getString(InterfaceConst.URL)));
+					List<DocumentResult> writeResults = JavaCloudantUtil.batchWrite(config.originalsStrings(), jsonSubArray);
+					boolean someFailed = writeResults.stream().anyMatch(doc -> doc.isOk() == null || !doc.isOk());
+					if (someFailed) {
+						// logging not needed - user can enable `errors.log.enable` if required
+						for (int i = 0; i < writeResults.size(); i++) {
+							DocumentResult writeResult = writeResults.get(i);
+							if (writeResult.isOk() == null || !writeResult.isOk()) {
+								reporter.report(accumulatedSinkRecords.get(b * batchSize + i),
+										new RuntimeException(String.format("Failed to batch write document to Cloudant with error %s reason %s",
+												writeResult.getError(), writeResult.getReason())));
+							}
+						}
 					}
 				}
-			}
-		} catch (RuntimeException re) {
-			LOG.error(String.format("Exception thrown when trying to write documents: %s", re.getMessage()));
-			if (reporter != null) {
-				if (accumulatedSinkRecords != null) {
-					// all failed
-					for (SinkRecord r : accumulatedSinkRecords) {
-						reporter.report(r, re);
-					}
-				}
-			} else {
+
+				// if we got here, then the batch operation succeeded (ie no network failure and 2xx response)
+				// therefore we can clear out the accumulated sink records
+				// any individual failures reported back from the response to batch write will have been reported
+				// and potentially logged and/or sent to dlq if the user configured these
+				accumulatedSinkRecords = null;
+			} catch (RuntimeException re) {
+				// below we re-wrap the exception as a nicety - it's not required, see explanation below
+
+				// WorkerSinkTask#commitOffsets will catch any Throwable and will not advance the offsets, meaning
+				// that everything outstanding in accumulatedSinkRecords (and potentially more if put is called again)
+				// will be attempted to be re-written
+
+				// logging not needed - WorkerSinkTask#onCommitCompleted will log error including the below message
 				throw new ConnectException("Exception thrown when trying to write documents", re);
 			}
-		} finally {
-			accumulatedSinkRecords = null;
 		}
 	}
 	

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
@@ -39,6 +39,7 @@ import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
 public class CloudantSinkErrorTest {
 
@@ -132,7 +133,6 @@ public class CloudantSinkErrorTest {
         SinkTaskContext mockContext = mock(SinkTaskContext.class);
 
         expect(mockContext.errantRecordReporter()).andReturn(mockRecordReporter).anyTimes();
-        expect(mockRecordReporter.report(eq(sr), eq(exception))).andReturn(null);
         expect(mockCloudant.postBulkDocs(anyObject())).andThrow(exception).anyTimes();
         expect(mockCloudant.putDatabase(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult(mockOk)).anyTimes();
 
@@ -169,6 +169,8 @@ public class CloudantSinkErrorTest {
         } catch (ConnectException connectException) {
             Assert.assertEquals("Exception thrown when trying to write documents", connectException.getMessage());
         }
+        // no expects for this - should never be called
+        verify(mockRecordReporter);
     }
 
     @After

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
@@ -1,20 +1,27 @@
+/*
+ * Copyright © 2022 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package com.ibm.cloud.cloudant.kafka.connect;
 
 import com.ibm.cloud.cloudant.kafka.connect.utils.ServiceCallUtils;
 import com.ibm.cloud.cloudant.v1.Cloudant;
-import com.ibm.cloud.cloudant.v1.model.ChangesResult;
 import com.ibm.cloud.cloudant.v1.model.DocumentResult;
 import com.ibm.cloud.cloudant.v1.model.Ok;
-import com.ibm.cloud.sdk.core.http.Response;
-import com.ibm.cloud.sdk.core.http.ServiceCall;
-import com.ibm.cloud.sdk.core.http.ServiceCallback;
-import io.reactivex.Single;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.easymock.EasyMock;
-import org.easymock.Mock;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.powermock.api.easymock.PowerMock;
 
@@ -23,12 +30,9 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
@@ -37,24 +41,61 @@ public class CloudantSinkErrorTest {
 
     private static final String connectionName = "_mock";
 
+    // test that record reporter is invoked for one bad document, but not for the other good document
     @Test
     public void testErrorsInResults() {
 
-
-        Cloudant mockCloudant = PowerMock.createMock(Cloudant.class);
+        Map map = new HashMap();
+        map.put("_id", "foo");
+        SinkRecord sr1 = new SinkRecord("test", 13, null, "0001", null, map, 0);
+        SinkRecord sr2 = new SinkRecord("test", 13, null, "0002", null, map, 0);
 
         List<DocumentResult> documentResults = new LinkedList<>();
 
+        Cloudant mockCloudant = PowerMock.createMock(Cloudant.class);
+        Ok mockOk = PowerMock.createMock(Ok.class);
+        ErrantRecordReporter mockRecordReporter = mock(ErrantRecordReporter.class);
+        SinkTaskContext mockContext = mock(SinkTaskContext.class);
+        DocumentResult mockDocumentResult1 = mock(DocumentResult.class);
+        DocumentResult mockDocumentResult2 = mock(DocumentResult.class);
+        documentResults.add(mockDocumentResult1);
+        documentResults.add(mockDocumentResult2);
 
-//        expect(mockCloudant.postBulkDocs(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult());
- //       expect(mockCloudant.putDatabase(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult());
+        expect(mockContext.errantRecordReporter()).andReturn(mockRecordReporter).anyTimes();
+        expect(mockRecordReporter.report(eq(sr1), anyObject())).andReturn(null);
+        expect(mockCloudant.postBulkDocs(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult(documentResults)).anyTimes();
+        expect(mockCloudant.putDatabase(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult(mockOk)).anyTimes();
+        // TODO confirm with the real service how bulk docs errors are reported - checking isOk may not be sufficient;
+        // first document result is bad, second is good
+        expect(mockDocumentResult1.isOk()).andReturn(false).anyTimes();
+        expect(mockDocumentResult2.isOk()).andReturn(true).anyTimes();
 
-
+        // force the task to use our mock client
+        ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
+        // setup task with some minimal config
         CloudantSinkTask cloudantSinkTask = new CloudantSinkTask();
-        ErrantRecordReporter recordReporter = mock(ErrantRecordReporter.class);
-        SinkTaskContext context = mock(SinkTaskContext.class);
-        expect(context.errantRecordReporter()).andReturn(recordReporter);
+        cloudantSinkTask.setContext(mockContext);
 
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("name", connectionName);
+        configMap.put("cloudant.since", "1000");
+        configMap.put("cloudant.url", "http://foo");
+        configMap.put("cloudant.db", "foo");
+        configMap.put("topics", "foo");
+
+        replay(mockCloudant);
+        replay(mockOk);
+        replay(mockRecordReporter);
+        replay(mockContext);
+        replay(mockDocumentResult1);
+        replay(mockDocumentResult2);
+
+        cloudantSinkTask.start(configMap);
+        cloudantSinkTask.put(Collections.singleton(sr1));
+        cloudantSinkTask.put(Collections.singleton(sr2));
+        cloudantSinkTask.flush(new HashMap<>());
+
+        EasyMock.verify(mockRecordReporter);
 
     }
 
@@ -73,7 +114,7 @@ public class CloudantSinkErrorTest {
         SinkTaskContext mockContext = mock(SinkTaskContext.class);
 
         expect(mockContext.errantRecordReporter()).andReturn(mockRecordReporter).anyTimes();
-        expect(mockRecordReporter.report(sr, exception)).andReturn(null);
+        expect(mockRecordReporter.report(eq(sr), eq(exception))).andReturn(null);
         expect(mockCloudant.postBulkDocs(anyObject())).andThrow(exception).anyTimes();
         expect(mockCloudant.putDatabase(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult(mockOk)).anyTimes();
 

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
@@ -45,6 +45,9 @@ public class CloudantSinkErrorTest {
     @Test
     public void testErrorsInResults() {
 
+        //
+        // given
+        //
         Map map = new HashMap();
         map.put("_id", "foo");
         SinkRecord sr1 = new SinkRecord("test", 13, null, "0001", null, map, 0);
@@ -90,19 +93,29 @@ public class CloudantSinkErrorTest {
         replay(mockDocumentResult1);
         replay(mockDocumentResult2);
 
+        //
+        // when
+        //
         cloudantSinkTask.start(configMap);
         cloudantSinkTask.put(Collections.singleton(sr1));
         cloudantSinkTask.put(Collections.singleton(sr2));
         cloudantSinkTask.flush(new HashMap<>());
 
+        //
+        // then
+        //
         EasyMock.verify(mockRecordReporter);
 
+        // TODO more asserts?
     }
 
     // verify that throwing an exception causes record reporter to be invoked
     @Test
     public void testExceptionWhenCallingPostBulkDocs() {
 
+        //
+        // given
+        //
         Map map = new HashMap();
         map.put("_id", "foo");
         SinkRecord sr = new SinkRecord("test", 13, null, "0001", null, map, 0);
@@ -136,11 +149,18 @@ public class CloudantSinkErrorTest {
         replay(mockRecordReporter);
         replay(mockContext);
 
+        //
+        // when
+        //
         cloudantSinkTask.start(configMap);
         cloudantSinkTask.put(Collections.singleton(sr));
         cloudantSinkTask.flush(new HashMap<>());
 
+        //
+        // then
+        //
         EasyMock.verify(mockRecordReporter);
 
+        // TODO more asserts?
     }
 }

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
@@ -1,0 +1,105 @@
+package com.ibm.cloud.cloudant.kafka.connect;
+
+import com.ibm.cloud.cloudant.kafka.connect.utils.ServiceCallUtils;
+import com.ibm.cloud.cloudant.v1.Cloudant;
+import com.ibm.cloud.cloudant.v1.model.ChangesResult;
+import com.ibm.cloud.cloudant.v1.model.DocumentResult;
+import com.ibm.cloud.cloudant.v1.model.Ok;
+import com.ibm.cloud.sdk.core.http.Response;
+import com.ibm.cloud.sdk.core.http.ServiceCall;
+import com.ibm.cloud.sdk.core.http.ServiceCallback;
+import io.reactivex.Single;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.easymock.EasyMock;
+import org.easymock.Mock;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.powermock.api.easymock.PowerMock;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+
+public class CloudantSinkErrorTest {
+
+    private static final String connectionName = "_mock";
+
+    @Test
+    public void testErrorsInResults() {
+
+
+        Cloudant mockCloudant = PowerMock.createMock(Cloudant.class);
+
+        List<DocumentResult> documentResults = new LinkedList<>();
+
+
+//        expect(mockCloudant.postBulkDocs(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult());
+ //       expect(mockCloudant.putDatabase(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult());
+
+
+        CloudantSinkTask cloudantSinkTask = new CloudantSinkTask();
+        ErrantRecordReporter recordReporter = mock(ErrantRecordReporter.class);
+        SinkTaskContext context = mock(SinkTaskContext.class);
+        expect(context.errantRecordReporter()).andReturn(recordReporter);
+
+
+    }
+
+    // verify that throwing an exception causes record reporter to be invoked
+    @Test
+    public void testExceptionWhenCallingPostBulkDocs() {
+
+        Map map = new HashMap();
+        map.put("_id", "foo");
+        SinkRecord sr = new SinkRecord("test", 13, null, "0001", null, map, 0);
+        Exception exception = new RuntimeException("eek!");
+
+        Cloudant mockCloudant = PowerMock.createMock(Cloudant.class);
+        Ok mockOk = PowerMock.createMock(Ok.class);
+        ErrantRecordReporter mockRecordReporter = mock(ErrantRecordReporter.class);
+        SinkTaskContext mockContext = mock(SinkTaskContext.class);
+
+        expect(mockContext.errantRecordReporter()).andReturn(mockRecordReporter).anyTimes();
+        expect(mockRecordReporter.report(sr, exception)).andReturn(null);
+        expect(mockCloudant.postBulkDocs(anyObject())).andThrow(exception).anyTimes();
+        expect(mockCloudant.putDatabase(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult(mockOk)).anyTimes();
+
+        // force the task to use our mock client
+        ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
+        // setup task with some minimal config
+        CloudantSinkTask cloudantSinkTask = new CloudantSinkTask();
+        cloudantSinkTask.setContext(mockContext);
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put("name", connectionName);
+        configMap.put("cloudant.since", "1000");
+        configMap.put("cloudant.url", "http://foo");
+        configMap.put("cloudant.db", "foo");
+        configMap.put("topics", "foo");
+
+        replay(mockCloudant);
+        replay(mockOk);
+        replay(mockRecordReporter);
+        replay(mockContext);
+
+        cloudantSinkTask.start(configMap);
+        cloudantSinkTask.put(Collections.singleton(sr));
+        cloudantSinkTask.flush(new HashMap<>());
+
+        EasyMock.verify(mockRecordReporter);
+
+    }
+}

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.easymock.EasyMock;
+import org.junit.After;
 import org.junit.Test;
 import org.powermock.api.easymock.PowerMock;
 
@@ -77,7 +78,6 @@ public class CloudantSinkErrorTest {
         ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
         // setup task with some minimal config
         CloudantSinkTask cloudantSinkTask = new CloudantSinkTask();
-        cloudantSinkTask.setContext(mockContext);
 
         Map<String, String> configMap = new HashMap<>();
         configMap.put("name", connectionName);
@@ -96,6 +96,7 @@ public class CloudantSinkErrorTest {
         //
         // when
         //
+        cloudantSinkTask.initialize(mockContext);
         cloudantSinkTask.start(configMap);
         cloudantSinkTask.put(Collections.singleton(sr1));
         cloudantSinkTask.put(Collections.singleton(sr2));
@@ -135,7 +136,6 @@ public class CloudantSinkErrorTest {
         ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
         // setup task with some minimal config
         CloudantSinkTask cloudantSinkTask = new CloudantSinkTask();
-        cloudantSinkTask.setContext(mockContext);
 
         Map<String, String> configMap = new HashMap<>();
         configMap.put("name", connectionName);
@@ -152,6 +152,7 @@ public class CloudantSinkErrorTest {
         //
         // when
         //
+        cloudantSinkTask.initialize(mockContext);
         cloudantSinkTask.start(configMap);
         cloudantSinkTask.put(Collections.singleton(sr));
         cloudantSinkTask.flush(new HashMap<>());
@@ -162,5 +163,10 @@ public class CloudantSinkErrorTest {
         EasyMock.verify(mockRecordReporter);
 
         // TODO more asserts?
+    }
+
+    @After
+    public void teardown() {
+        PowerMock.resetAll();
     }
 }

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkErrorTest.java
@@ -69,15 +69,14 @@ public class CloudantSinkErrorTest {
         documentResults.add(mockDocumentResult2);
 
         expect(mockContext.errantRecordReporter()).andReturn(mockRecordReporter).anyTimes();
-        expect(mockRecordReporter.report(eq(sr1), anyObject())).andReturn(null);
+        expect(mockRecordReporter.report(eq(sr1), anyObject(RuntimeException.class))).andReturn(null);
         expect(mockCloudant.postBulkDocs(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult(documentResults)).anyTimes();
         expect(mockCloudant.putDatabase(anyObject())).andReturn(ServiceCallUtils.makeServiceCallWithResult(mockOk)).anyTimes();
-        // TODO confirm with the real service how bulk docs errors are reported - checking isOk may not be sufficient;
         // first document result is bad, second is good
-        expect(mockDocumentResult1.isOk()).andReturn(false).anyTimes();
+        expect(mockDocumentResult1.isOk()).andReturn(null).anyTimes(); // NB service may return null or false if not ok
         expect(mockDocumentResult1.getError()).andReturn("some error").anyTimes();
         expect(mockDocumentResult1.getReason()).andReturn("some cause").anyTimes();
-        expect(mockDocumentResult2.isOk()).andReturn(true).anyTimes();
+        expect(mockDocumentResult2.isOk()).andReturn(Boolean.TRUE).anyTimes();
 
         // force the task to use our mock client
         ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
@@ -111,8 +110,6 @@ public class CloudantSinkErrorTest {
         // then
         //
         EasyMock.verify(mockRecordReporter);
-
-        // TODO more asserts?
     }
 
     // verify that throwing an exception causes connect exception to be thrown from flush

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTaskTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/CloudantSinkTaskTest.java
@@ -14,9 +14,7 @@
 package com.ibm.cloud.cloudant.kafka.connect;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.ibm.cloud.cloudant.v1.model.ChangesResult;
 import com.ibm.cloud.cloudant.v1.model.ChangesResultItem;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ServiceCallUtils.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ServiceCallUtils.java
@@ -31,7 +31,7 @@ public class ServiceCallUtils {
         return new ServiceCall<T>() {
             @Override
             public ServiceCall<T> addHeader(String s, String s1) {
-                return null;
+                throw new UnsupportedOperationException("Unsupported in mock");
             }
 
             @Override
@@ -41,17 +41,17 @@ public class ServiceCallUtils {
 
             @Override
             public void enqueue(ServiceCallback<T> serviceCallback) {
-
+                throw new UnsupportedOperationException("Unsupported in mock");
             }
 
             @Override
             public Single<Response<T>> reactiveRequest() {
-                return null;
+                throw new UnsupportedOperationException("Unsupported in mock");
             }
 
             @Override
             public void cancel() {
-
+                throw new UnsupportedOperationException("Unsupported in mock");
             }
         };
     }

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ServiceCallUtils.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ServiceCallUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright © 2022 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.ibm.cloud.cloudant.kafka.connect.utils;
 
 import com.ibm.cloud.sdk.core.http.Response;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ServiceCallUtils.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ServiceCallUtils.java
@@ -1,0 +1,46 @@
+package com.ibm.cloud.cloudant.kafka.connect.utils;
+
+import com.ibm.cloud.sdk.core.http.Response;
+import com.ibm.cloud.sdk.core.http.ServiceCall;
+import com.ibm.cloud.sdk.core.http.ServiceCallback;
+import io.reactivex.Single;
+import org.powermock.api.easymock.PowerMock;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+public class ServiceCallUtils {
+
+    public static <T> ServiceCall<T> makeServiceCallWithResult(T result) {
+        Response<T> mockResponse = PowerMock.createMock(Response.class);
+        expect(mockResponse.getResult()).andReturn(result).anyTimes();
+        replay(mockResponse);
+        return new ServiceCall<T>() {
+            @Override
+            public ServiceCall<T> addHeader(String s, String s1) {
+                return null;
+            }
+
+            @Override
+            public Response<T> execute() throws RuntimeException {
+                return mockResponse;
+            }
+
+            @Override
+            public void enqueue(ServiceCallback<T> serviceCallback) {
+
+            }
+
+            @Override
+            public Single<Response<T>> reactiveRequest() {
+                return null;
+            }
+
+            @Override
+            public void cancel() {
+
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Handle errors in sink connector arising from posting to bulk_docs endpoint:

- Individual errors in batch response are reported to the error reporter, if present. This allows the original events to be sent to a DLQ and/or logged according to standard kafka config
- For more serious network/HTTP errors, throw an exception. This will ensure that the offsets are not committed and the event can be retried.

Additionally:
- Break up calls to bulk_docs into batches to avoid large request bodies
- Add tests for error handling

Fixes #84 