### PR TITLE
chore: exclude members from DCO check

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+# Exclude members from DCO sign-off on commits
+require:
+  members: false


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes - N/A
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes - N/A
- [x] Completed the PR template below:

## Description

Add DCO config to bypass DCO check for members.

## Approach

```
require:
  members: false
```
Stops the DCO bot from expecting a sign-off on commits that are _verified_ as coming from a member. This means the commits must be cryptographically signed.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"
