### PR TITLE
feat: add isDesignDocument predicate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -97,7 +97,7 @@
       {
         "hashed_secret": "333f0f8814d63e7268f80e1e65e7549137d2350c",
         "is_verified": false,
-        "line_number": 267,
+        "line_number": 278,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 # UNRELEASED
-- [BREAKING CHANGE] Source connector flatten, schema generation and omit design documents options have been replaced by message tranforms. See README for details.
+- [BREAKING CHANGE] Source connector flatten, schema generation and omit design documents options have been replaced by message transforms. See README for details.
 - [BREAKING CHANGE] Source connector now emits `java.util.Map` (not `String`) record values by default. See README for details.
 - [BREAKING CHANGE] Source connector now emits tombstone events for deleted documents. See [single message transforms](README.md#single-message-transforms) section in README for details.
 - [BREAKING CHANGE] Publish releases to https://github.com/IBM/cloudant-kafka-connector/releases.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ The examples below demonstrate modifying records produced by the Cloudant source
     transforms.MapToStruct.type=com.ibm.cloud.cloudant.kafka.connect.transforms.MapToStruct
     ```
 
+1. Omit design documents from the produced events by using the Kafka built-in `org.apache.kafka.connect.transforms.Filter`
+   in conjunction with the predicate `com.ibm.cloud.cloudant.kafka.connect.transforms.predicates.IsDesignDocument`.
+    ```
+    transforms=omitDesignDocs
+    transforms.omitDesignDocs.type=org.apache.kafka.connect.transforms.Filter
+    transforms.omitDesignDocs.predicate=isDesignDoc
+
+    predicates=isDesignDoc
+    predicates.isDesignDoc.type=com.ibm.cloud.cloudant.kafka.connect.transforms.predicates.IsDesignDocument
+    ```
+
 ### Authentication
 
 In order to read from or write to Cloudant, some authentication properties need to be configured. These properties are common to both the source and sink connector.

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/common/CloudantConst.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/common/CloudantConst.java
@@ -14,6 +14,7 @@
 package com.ibm.cloud.cloudant.kafka.common;
 
 public class CloudantConst {
+    public static final String CLOUDANT_DESIGN_PREFIX = "_design/";
     public static final String CLOUDANT_DOC_ID = "_id";
     public static final String CLOUDANT_REV = "_rev";
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/common/MessageKey.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/common/MessageKey.java
@@ -69,5 +69,7 @@ public class MessageKey {
     public static final String CLOUDANT_STRUCT_UNHANDLED_TYPE = "CloudantStructUnhandledType";
     public static final String CLOUDANT_STRUCT_UNKNOWN_TYPE = "CloudantStructUnknownType";
 
+    public static final String CLOUDANT_KEY_NO_ID =	"CloudantKeyNoId";
+
     public static final String GUID_SCHEMA = "GuidSchema";
 }

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocument.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocument.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2022 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.ibm.cloud.cloudant.kafka.transforms.predicates;
+
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.transforms.predicates.Predicate;
+import org.apache.kafka.connect.transforms.util.Requirements;
+import com.ibm.cloud.cloudant.kafka.common.MessageKey;
+import com.ibm.cloud.cloudant.kafka.common.utils.ResourceBundleUtil;
+import static com.ibm.cloud.cloudant.kafka.common.CloudantConst.CLOUDANT_DESIGN_PREFIX;
+import static com.ibm.cloud.cloudant.kafka.common.CloudantConst.CLOUDANT_DOC_ID;
+
+public class IsDesignDocument implements Predicate<SourceRecord> {
+
+    private static final ConfigDef EMPTY_CONFIG_DEF = new ConfigDef();
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // No-op; no configuration
+    }
+
+    @Override
+    public ConfigDef config() {
+        return EMPTY_CONFIG_DEF;
+    }
+
+    @Override
+    public boolean test(SourceRecord record) {
+        Schema schema = record.keySchema();
+        Object recordKey = record.key();
+        if (schema == null || recordKey == null || schema.type() != Type.MAP || schema.keySchema().type() != Type.STRING || schema.valueSchema().type() != Type.STRING) {
+            // Unexpected schema, check if the key is a map
+            // No need to use message file here, because this purpose gets inserted into the middle of an untranslated Kafka message
+            Requirements.requireMap(recordKey, "record key in IsDesignDocument predicate");
+            // If it is not a map this will throw
+        }
+        Map<String, String> key = (Map<String, String>) recordKey;
+        String id = key.get(CLOUDANT_DOC_ID);
+        if (id == null) {
+            throw new DataException(String.format(ResourceBundleUtil.get(MessageKey.CLOUDANT_KEY_NO_ID), CLOUDANT_DOC_ID));
+        } else {
+            return id.startsWith(CLOUDANT_DESIGN_PREFIX);
+        }
+    }
+
+    @Override
+    public void close() {
+        // No-op; nothing to close
+    }
+    
+}

--- a/src/main/resources/message_en_US.properties
+++ b/src/main/resources/message_en_US.properties
@@ -81,3 +81,5 @@ CloudantStructUndetectableArrayType=Cannot infer array element type for arrays t
 CloudantStructMixedTypeArray=Cannot generate schemas for mixed type arrays, consider using the %s SMT.
 CloudantStructUnhandledType=Cannot transform schema type %s.
 CloudantStructUnknownType=Could not infer schema for class %s.
+
+CloudantKeyNoId=The record key does not have the required entry %s.

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocumentTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocumentTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2022 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.ibm.cloud.cloudant.kafka.transforms.predicates;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.Collections;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+import com.ibm.cloud.cloudant.kafka.common.CloudantConst;
+
+public class IsDesignDocumentTest {
+
+    // Record key schema is Map<String, String>
+    private static final Schema RECORD_KEY_SCHEMA = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build();
+
+    IsDesignDocument isDDoc = new IsDesignDocument();
+
+    private SourceRecord wrapInRecord(Schema keySchema, Object key) {
+        return new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), "test", keySchema, key, null, null);
+    }
+
+    @Test(expected = DataException.class)
+    public void testNullSchemaAndKey() {
+        isDDoc.test(wrapInRecord(null, null));
+    }
+
+    @Test(expected = DataException.class)
+    public void testNullKeyValue() {
+        isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, null));
+    }
+
+    @Test(expected = DataException.class)
+    public void testWrongKeyType() {
+        isDDoc.test(wrapInRecord(Schema.STRING_SCHEMA, "foo"));
+    }
+
+    @Test
+    public void testDesignDocument() {
+        assertTrue("The design document should be filtered.",
+            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, "_design/foo"))));
+    }
+
+    @Test
+    public void testNearlyDesignDocument() {
+        assertFalse("The document should not be filtered.",
+            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, "_designfoo"))));
+    }
+
+    @Test
+    public void testNotDesignDocument() {
+        assertFalse("The document should not be filtered.",
+            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, "foo"))));
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Add isDesignDocument predicate

Fixes #97 

## Approach

Add predicate class that checks the source record key for an `_id` field with a `_design/` prefix.
Note I used the anticipated package name from #96 in the `README` rather than the current package name.

## Schema & API Changes

- Replaces omitDesignDocs option removed by #63 

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - `com.ibm.cloud.cloudant.kafka.transforms.predicates.IsDesignDocumentTest`

## Monitoring and Logging

- "No change"
