### PR TITLE
refactor: connector moves and renames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [REFACTOR] Source and sink connector moves and renames
 - [BREAKING CHANGE] Source connector flatten, schema generation and omit design documents options have been replaced by message transforms. See README for details.
 - [BREAKING CHANGE] Source connector now emits `java.util.Map` (not `String`) record values by default. See README for details.
 - [BREAKING CHANGE] Source connector now emits tombstone events for deleted documents. See [single message transforms](README.md#single-message-transforms) section in README for details.

--- a/README.md
+++ b/README.md
@@ -226,18 +226,18 @@ For use with `iam`, `container`, or `vpc` authentication.
 
 In addition to those properties related to authentication, the Cloudant source connector supports the following properties:
 
-Parameter | Value | Required | Default value | Description
----:|:---|:---|:---|:---
-name|cloudant-source|YES|None|A unique name to identify the connector with.
-connector.class|com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector|YES|None|The connector class name.
-topics|\<topic1\>,\<topic2\>,..|YES|None|A list of topics you want messages to be written to.
-cloudant.url|https://\<uuid\>.cloudantnosqldb.appdomain.cloud|YES|None|The Cloudant server to read documents from.
-cloudant.db|\<your-db\>|YES|None|The Cloudant database to read documents from.
-cloudant.since|1-g1AAAAETeJzLYWBgYMlgTmGQT0lKzi9..|NO|0|The first change sequence to process from the Cloudant database above. 0 will apply all available document changes.
-batch.size|400|NO|1000|The batch size used to bulk read from the Cloudant database.
-cloudant.omit.design.docs|false|NO|false| Set to true to omit design documents from the messages produced.
-cloudant.value.schema.struct|false|NO|false| _EXPERIMENTAL_ Set to true to generate a `org.apache.kafka.connect.data.Schema.Type.STRUCT` schema and send the Cloudant document payload as a `org.apache.kafka.connect.data.Struct` using the schema instead of the default of a string of the JSON document content when using the Cloudant source connector.
-cloudant.value.schema.struct.flatten|false|NO|false| _EXPERIMENTAL_ Set to true to flatten nested arrays and objects from the Cloudant document during struct generation. Only used when cloudant.value.schema.struct is true and allows processing of JSON arrays with mixed element types when using that option.
+Parameter | Value                                                                  | Required | Default value | Description
+---:|:-----------------------------------------------------------------------|:---|:---|:---
+name| cloudant-source                                                        |YES|None|A unique name to identify the connector with.
+connector.class| com.ibm.cloud.cloudant.kafka.SourceChangesConnector |YES|None|The connector class name.
+topics| \<topic1\>,\<topic2\>,..                                               |YES|None|A list of topics you want messages to be written to.
+cloudant.url| https://\<uuid\>.cloudantnosqldb.appdomain.cloud                       |YES|None|The Cloudant server to read documents from.
+cloudant.db| \<your-db\>                                                            |YES|None|The Cloudant database to read documents from.
+cloudant.since| 1-g1AAAAETeJzLYWBgYMlgTmGQT0lKzi9..                                    |NO|0|The first change sequence to process from the Cloudant database above. 0 will apply all available document changes.
+batch.size| 400                                                                    |NO|1000|The batch size used to bulk read from the Cloudant database.
+cloudant.omit.design.docs| false                                                                  |NO|false| Set to true to omit design documents from the messages produced.
+cloudant.value.schema.struct| false                                                                  |NO|false| _EXPERIMENTAL_ Set to true to generate a `org.apache.kafka.connect.data.Schema.Type.STRUCT` schema and send the Cloudant document payload as a `org.apache.kafka.connect.data.Struct` using the schema instead of the default of a string of the JSON document content when using the Cloudant source connector.
+cloudant.value.schema.struct.flatten| false                                                                  |NO|false| _EXPERIMENTAL_ Set to true to flatten nested arrays and objects from the Cloudant document during struct generation. Only used when cloudant.value.schema.struct is true and allows processing of JSON arrays with mixed element types when using that option.
 
 #### Example
 
@@ -245,7 +245,7 @@ To read from a Cloudant database as source and write documents to a Kafka topic,
 
 ```
 name=cloudant-source
-connector.class=com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector
+connector.class=com.ibm.cloud.cloudant.kafka.SourceChangesConnector
 topics=mytopic
 cloudant.url=https://some-uuid.cloudantnosqldb.appdomain.cloud
 cloudant.db=my-db
@@ -259,7 +259,7 @@ In addition to those properties related to authentication, the Cloudant sink con
 Parameter | Value | Required | Default value | Description
 ---:|:---|:---|:---|:---
 name|cloudant-sink|YES|None|A unique name to identify the connector with.
-connector.class|com.ibm.cloud.cloudant.kafka.connect.CloudantSinkConnector|YES|None|The connector class name.
+connector.class|com.ibm.cloud.cloudant.kafka.SinkConnector|YES|None|The connector class name.
 topics|\<topic1\>,\<topic2\>,..|YES|None|The list of topics you want to consume messages from.
 cloudant.url|https://\<your-account\>.cloudant.com|YES|None|The Cloudant server to write documents to.
 cloudant.db|\<your-db\>|YES|None|The Cloudant database to write documents to.
@@ -273,7 +273,7 @@ To consume messages from a Kafka topic and save as documents into a Cloudant dat
 
 ```
 name=cloudant-sink
-connector.class=com.ibm.cloud.cloudant.kafka.connect.CloudantSinkConnector
+connector.class=com.ibm.cloud.cloudant.kafka.SinkConnector
 topics=mytopic
 cloudant.url=https://some-uuid.cloudantnosqldb.appdomain.cloud
 cloudant.db=my-db

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/SinkConnector.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/SinkConnector.java
@@ -11,14 +11,17 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.connect;
+package com.ibm.cloud.cloudant.kafka;
 
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloud.cloudant.kafka.common.utils.JavaCloudantUtil;
+import com.ibm.cloud.cloudant.kafka.connect.CachedClientManager;
+import com.ibm.cloud.cloudant.kafka.connect.SinkConnectorConfig;
+import com.ibm.cloud.cloudant.kafka.connect.ConfigValidator;
+import com.ibm.cloud.cloudant.kafka.connect.SinkTask;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,15 +30,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CloudantSourceConnector extends SourceConnector {
+public class SinkConnector extends org.apache.kafka.connect.sink.SinkConnector {
 
-    private static Logger LOG = LoggerFactory.getLogger(CloudantSourceConnector.class);
+    private static Logger LOG = LoggerFactory.getLogger(SinkConnector.class);
 
     private Map<String, String> configProperties;
 
     @Override
     public ConfigDef config() {
-        return CloudantSourceConnectorConfig.CONFIG_DEF;
+        return SinkConnectorConfig.CONFIG_DEF;
+    }
+
+
+    @Override
+    public String version() {
+        return JavaCloudantUtil.VERSION;
     }
 
     @Override
@@ -44,35 +53,32 @@ public class CloudantSourceConnector extends SourceConnector {
     }
 
     @Override
+    public Class<? extends Task> taskClass() {
+        return SinkTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        List<Map<String, String>> taskConfigs = new ArrayList<>(maxTasks);
+
+        for (int i = 0; i < maxTasks; i++) {
+            Map<String, String> taskProps = new HashMap<>(configProperties);
+            // add task specific properties here (if any)
+            taskProps.put(InterfaceConst.TASK_NUMBER, String.valueOf(i));
+
+            taskConfigs.add(taskProps);
+        }
+        return taskConfigs;
+    }
+
+    @Override
     public void stop() {
         CachedClientManager.removeInstance(configProperties);
     }
 
     @Override
-    public Class<? extends Task> taskClass() {
-        return CloudantSourceTask.class;
-    }
-
-    @Override
-    public List<Map<String, String>> taskConfigs(int maxTasks) {
-        if (maxTasks > 1) {
-            LOG.warn(String.format("tasks.max requested was %d, but only 1 task supported", maxTasks));
-        }
-        List<Map<String, String>> taskConfigs = new ArrayList<>(1);
-        Map<String, String> taskProps = new HashMap<>(configProperties);
-        taskProps.put(InterfaceConst.TASK_NUMBER, String.valueOf(0));
-        taskConfigs.add(taskProps);
-        return taskConfigs;
-    }
-
-    @Override
-    public String version() {
-        return JavaCloudantUtil.VERSION;
-    }
-
-    @Override
     public Config validate(Map<String, String> connectorConfigs) {
-        CloudantConfigValidator validator = new CloudantConfigValidator(connectorConfigs, config());
+        ConfigValidator validator = new ConfigValidator(connectorConfigs, config());
         return validator.validate();
     }
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/SourceChangesConnector.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/SourceChangesConnector.java
@@ -11,14 +11,18 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.connect;
+package com.ibm.cloud.cloudant.kafka;
 
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloud.cloudant.kafka.common.utils.JavaCloudantUtil;
+import com.ibm.cloud.cloudant.kafka.connect.CachedClientManager;
+import com.ibm.cloud.cloudant.kafka.connect.SourceChangesConnectorConfig;
+import com.ibm.cloud.cloudant.kafka.connect.ConfigValidator;
+import com.ibm.cloud.cloudant.kafka.connect.SourceChangesTask;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,21 +31,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CloudantSinkConnector extends SinkConnector {
+public class SourceChangesConnector extends SourceConnector {
 
-    private static Logger LOG = LoggerFactory.getLogger(CloudantSinkConnector.class);
+    private static Logger LOG = LoggerFactory.getLogger(SourceChangesConnector.class);
 
     private Map<String, String> configProperties;
 
     @Override
     public ConfigDef config() {
-        return CloudantSinkConnectorConfig.CONFIG_DEF;
-    }
-
-
-    @Override
-    public String version() {
-        return JavaCloudantUtil.VERSION;
+        return SourceChangesConnectorConfig.CONFIG_DEF;
     }
 
     @Override
@@ -50,32 +48,35 @@ public class CloudantSinkConnector extends SinkConnector {
     }
 
     @Override
-    public Class<? extends Task> taskClass() {
-        return CloudantSinkTask.class;
-    }
-
-    @Override
-    public List<Map<String, String>> taskConfigs(int maxTasks) {
-        List<Map<String, String>> taskConfigs = new ArrayList<>(maxTasks);
-
-        for (int i = 0; i < maxTasks; i++) {
-            Map<String, String> taskProps = new HashMap<>(configProperties);
-            // add task specific properties here (if any)
-            taskProps.put(InterfaceConst.TASK_NUMBER, String.valueOf(i));
-
-            taskConfigs.add(taskProps);
-        }
-        return taskConfigs;
-    }
-
-    @Override
     public void stop() {
         CachedClientManager.removeInstance(configProperties);
     }
 
     @Override
+    public Class<? extends Task> taskClass() {
+        return SourceChangesTask.class;
+    }
+
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        if (maxTasks > 1) {
+            LOG.warn(String.format("tasks.max requested was %d, but only 1 task supported", maxTasks));
+        }
+        List<Map<String, String>> taskConfigs = new ArrayList<>(1);
+        Map<String, String> taskProps = new HashMap<>(configProperties);
+        taskProps.put(InterfaceConst.TASK_NUMBER, String.valueOf(0));
+        taskConfigs.add(taskProps);
+        return taskConfigs;
+    }
+
+    @Override
+    public String version() {
+        return JavaCloudantUtil.VERSION;
+    }
+
+    @Override
     public Config validate(Map<String, String> connectorConfigs) {
-        CloudantConfigValidator validator = new CloudantConfigValidator(connectorConfigs, config());
+        ConfigValidator validator = new ConfigValidator(connectorConfigs, config());
         return validator.validate();
     }
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/ConfigValidator.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/ConfigValidator.java
@@ -30,12 +30,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 // custom validations, for complex validation rules across multiple fields
-public class CloudantConfigValidator {
+public class ConfigValidator {
 
     private Map<String, ConfigValue> values;
     private List<ConfigValue> validations;
 
-    public CloudantConfigValidator(Map<String, String> props, ConfigDef config) {
+    public ConfigValidator(Map<String, String> props, ConfigDef config) {
 
         validations = config.validate(props);
         values = validations.stream().collect(Collectors.toMap(ConfigValue::name, Function.identity()));

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/ConnectorConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/ConnectorConfig.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 
 import java.util.Map;
 
-public class CloudantConnectorConfig extends AbstractConfig {
+public class ConnectorConfig extends AbstractConfig {
 
     protected static final String DATABASE_GROUP = "Database";
     protected static final String AUTH_TYPE_DEFAULT = Authenticator.AUTHTYPE_IAM;
@@ -212,11 +212,11 @@ public class CloudantConnectorConfig extends AbstractConfig {
                         ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DISP));
     }
 
-    public CloudantConnectorConfig(ConfigDef definition, Map<?, ?> originals, boolean doLog) {
+    public ConnectorConfig(ConfigDef definition, Map<?, ?> originals, boolean doLog) {
         super(definition, originals, doLog);
     }
 
-    public CloudantConnectorConfig(ConfigDef definition, Map<?, ?> originals) {
+    public ConnectorConfig(ConfigDef definition, Map<?, ?> originals) {
         super(definition, originals);
     }
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SinkConnectorConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SinkConnectorConfig.java
@@ -20,12 +20,12 @@ import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.Map;
 
-public class CloudantSinkConnectorConfig extends CloudantConnectorConfig {
+public class SinkConnectorConfig extends ConnectorConfig {
 
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
     public static ConfigDef baseConfigDef() {
-        return new ConfigDef(CloudantConnectorConfig.CONFIG_DEF)
+        return new ConfigDef(ConnectorConfig.CONFIG_DEF)
                 // batch size
                 .define(InterfaceConst.BATCH_SIZE,
                         ConfigDef.Type.INT,
@@ -39,7 +39,7 @@ public class CloudantSinkConnectorConfig extends CloudantConnectorConfig {
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_BATCH_SIZE_DISP));
     }
 
-    protected CloudantSinkConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> originals) {
+    protected SinkConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> originals) {
         super(subclassConfigDef, originals);
     }
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SinkTask.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SinkTask.java
@@ -15,13 +15,13 @@ package com.ibm.cloud.cloudant.kafka.connect;
 
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloud.cloudant.kafka.common.utils.JavaCloudantUtil;
+import com.ibm.cloud.cloudant.kafka.SinkConnector;
 import com.ibm.cloud.cloudant.kafka.schema.ConnectRecordMapper;
 import com.ibm.cloud.cloudant.v1.model.DocumentResult;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,11 +32,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class CloudantSinkTask extends SinkTask {
+public class SinkTask extends org.apache.kafka.connect.sink.SinkTask {
 
-    private static Logger LOG = LoggerFactory.getLogger(CloudantSinkTask.class);
+    private static Logger LOG = LoggerFactory.getLogger(SinkTask.class);
 
-    private CloudantSinkTaskConfig config;
+    private SinkTaskConfig config;
 
     List<String> topics = null;
 
@@ -53,7 +53,7 @@ public class CloudantSinkTask extends SinkTask {
 
     @Override
     public String version() {
-        return new CloudantSinkConnector().version();
+        return new SinkConnector().version();
     }
 
     @Override
@@ -76,7 +76,7 @@ public class CloudantSinkTask extends SinkTask {
      */
     @Override
     public void start(Map<String, String> props) {
-        config = new CloudantSinkTaskConfig(props);
+        config = new SinkTaskConfig(props);
         taskNumber = config.getInt(InterfaceConst.TASK_NUMBER);
         topics = config.getList(InterfaceConst.TOPIC);
         batchSize = config.getInt(InterfaceConst.BATCH_SIZE);

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SinkTaskConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SinkTaskConfig.java
@@ -20,16 +20,15 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 
 import java.util.Map;
 
-public class CloudantSourceTaskConfig extends CloudantSourceConnectorConfig {
+public class SinkTaskConfig extends SinkConnectorConfig {
 
     // Expand this ConfigDef with task specific parameters
     static org.apache.kafka.common.config.ConfigDef config = new ConfigDef(baseConfigDef())
             .define(InterfaceConst.TASK_NUMBER,
                     Type.INT, InterfaceConst.DEFAULT_TASK_NUMBER, Importance.HIGH, InterfaceConst.TASK_NUMBER)
-            .define(InterfaceConst.TASKS_MAX,
-                    Type.INT, InterfaceConst.DEFAULT_TASKS_MAX, Importance.LOW, InterfaceConst.TASKS_MAX);
-
-    public CloudantSourceTaskConfig(Map<String, String> originals) {
+            .define(InterfaceConst.TASKS_MAX, Type.INT, InterfaceConst.DEFAULT_TASKS_MAX,
+                    Importance.LOW, InterfaceConst.TASKS_MAX);
+    public SinkTaskConfig(Map<String, String> originals) {
         super(config, originals);
     }
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesConnectorConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesConnectorConfig.java
@@ -23,12 +23,12 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 
 import java.util.Map;
 
-public class CloudantSourceConnectorConfig extends CloudantConnectorConfig {
+public class SourceChangesConnectorConfig extends ConnectorConfig {
 
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
     public static ConfigDef baseConfigDef() {
-        return new ConfigDef(CloudantConnectorConfig.CONFIG_DEF)
+        return new ConfigDef(ConnectorConfig.CONFIG_DEF)
                 // Cloudant last change sequence
                 .define(InterfaceConst.LAST_CHANGE_SEQ,
                         Type.STRING,
@@ -52,11 +52,11 @@ public class CloudantSourceConnectorConfig extends CloudantConnectorConfig {
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_BATCH_SIZE_DISP));
     }
 
-    public CloudantSourceConnectorConfig(Map<String, String> originals) {
+    public SourceChangesConnectorConfig(Map<String, String> originals) {
         super(CONFIG_DEF, originals, false);
     }
 
-    protected CloudantSourceConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> originals) {
+    protected SourceChangesConnectorConfig(ConfigDef subclassConfigDef, Map<String, String> originals) {
         super(subclassConfigDef, originals);
     }
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesTask.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesTask.java
@@ -14,13 +14,13 @@
 package com.ibm.cloud.cloudant.kafka.connect;
 
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
+import com.ibm.cloud.cloudant.kafka.SourceChangesConnector;
 import com.ibm.cloud.cloudant.kafka.schema.DocumentToSourceRecord;
 import com.ibm.cloud.cloudant.v1.Cloudant;
 import com.ibm.cloud.cloudant.v1.model.ChangesResult;
 import com.ibm.cloud.cloudant.v1.model.ChangesResultItem;
 import com.ibm.cloud.cloudant.v1.model.PostChangesOptions;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,14 +33,14 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class CloudantSourceTask extends SourceTask {
+public class SourceChangesTask extends org.apache.kafka.connect.source.SourceTask {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CloudantSourceTask.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SourceChangesTask.class);
     private static final String DEFAULT_CLOUDANT_LAST_SEQ = "0";
 
     private static final String OFFSET_KEY = "cloudant.url.and.db";
 
-    CloudantSourceTaskConfig config;
+    SourceChangesTaskConfig config;
     private String url = null;
     private String db = null;
     private List<String> topics = null;
@@ -94,13 +94,13 @@ public class CloudantSourceTask extends SourceTask {
 
     @Override
     public void start(Map<String, String> props) {
-        this.config = new CloudantSourceTaskConfig(props);
+        this.config = new SourceChangesTaskConfig(props);
         url = config.getString(InterfaceConst.URL);
         db = config.getString(InterfaceConst.DB);
         topics = config.getList(InterfaceConst.TOPIC);
         latestSequenceNumber = config.getString(InterfaceConst.LAST_CHANGE_SEQ);
         batchSize = config.getInt(InterfaceConst.BATCH_SIZE);
-        this.documentToSourceRecord = new DocumentToSourceRecord(offset(url, db), CloudantSourceTask::offsetValue);
+        this.documentToSourceRecord = new DocumentToSourceRecord(offset(url, db), SourceChangesTask::offsetValue);
 
         if (latestSequenceNumber == null) {
             latestSequenceNumber = DEFAULT_CLOUDANT_LAST_SEQ;
@@ -133,7 +133,7 @@ public class CloudantSourceTask extends SourceTask {
     }
 
     public String version() {
-        return new CloudantSourceConnector().version();
+        return new SourceChangesConnector().version();
     }
 
 }

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesTaskConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesTaskConfig.java
@@ -20,15 +20,16 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 
 import java.util.Map;
 
-public class CloudantSinkTaskConfig extends CloudantSinkConnectorConfig {
+public class SourceChangesTaskConfig extends SourceChangesConnectorConfig {
 
     // Expand this ConfigDef with task specific parameters
     static org.apache.kafka.common.config.ConfigDef config = new ConfigDef(baseConfigDef())
             .define(InterfaceConst.TASK_NUMBER,
                     Type.INT, InterfaceConst.DEFAULT_TASK_NUMBER, Importance.HIGH, InterfaceConst.TASK_NUMBER)
-            .define(InterfaceConst.TASKS_MAX, Type.INT, InterfaceConst.DEFAULT_TASKS_MAX,
-                    Importance.LOW, InterfaceConst.TASKS_MAX);
-    public CloudantSinkTaskConfig(Map<String, String> originals) {
+            .define(InterfaceConst.TASKS_MAX,
+                    Type.INT, InterfaceConst.DEFAULT_TASKS_MAX, Importance.LOW, InterfaceConst.TASKS_MAX);
+
+    public SourceChangesTaskConfig(Map<String, String> originals) {
         super(config, originals);
     }
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/transforms/ArrayFlatten.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/transforms/ArrayFlatten.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.transforms;
+package com.ibm.cloud.cloudant.kafka.connect.transforms;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/transforms/MapToStruct.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/transforms/MapToStruct.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.transforms;
+package com.ibm.cloud.cloudant.kafka.connect.transforms;
 
 import java.math.BigDecimal;
 import java.util.Date;

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/connect/transforms/predicates/IsDesignDocument.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/connect/transforms/predicates/IsDesignDocument.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.transforms.predicates;
+package com.ibm.cloud.cloudant.kafka.connect.transforms.predicates;
 
 import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/SinkConnectorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/SinkConnectorTest.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.connect;
+package com.ibm.cloud.cloudant.kafka;
 
 
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
@@ -27,9 +27,9 @@ import java.util.Map;
 /**
  * @author holger
  */
-public class CloudantSinkConnectorTest extends TestCase {
+public class SinkConnectorTest extends TestCase {
 
-    private CloudantSinkConnector connector;
+    private SinkConnector connector;
     private Map<String, String> targetProperties;
 
     protected void setUp() throws Exception {
@@ -37,7 +37,7 @@ public class CloudantSinkConnectorTest extends TestCase {
 
         targetProperties = ConnectorUtils.getTestProperties();
 
-        connector = new CloudantSinkConnector();
+        connector = new SinkConnector();
         ConnectorContext context = PowerMock.createMock(ConnectorContext.class);
         connector.initialize(context);
     }

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/SourceChangesConnectorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/SourceChangesConnectorTest.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.connect;
+package com.ibm.cloud.cloudant.kafka;
 
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloud.cloudant.kafka.connect.utils.ConnectorUtils;
@@ -28,12 +28,12 @@ import java.util.Map;
 /**
  * @author holger
  */
-public class CloudantSourceConnectorTest extends TestCase {
+public class SourceChangesConnectorTest extends TestCase {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private CloudantSourceConnector connector;
+    private SourceChangesConnector connector;
     private Map<String, String> sourceProperties;
 
 
@@ -45,13 +45,13 @@ public class CloudantSourceConnectorTest extends TestCase {
 
         sourceProperties = ConnectorUtils.getTestProperties();
 
-        connector = new CloudantSourceConnector();
+        connector = new SourceChangesConnector();
         ConnectorContext context = PowerMock.createMock(ConnectorContext.class);
         connector.initialize(context);
     }
 
     /**
-     * Test method for {@link com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector#stop()}.
+     * Test method for {@link SourceChangesConnector#stop()}.
      */
     public void testStop() {
     }
@@ -59,7 +59,7 @@ public class CloudantSourceConnectorTest extends TestCase {
 
     /**
      * Test method for
-     * {@link com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector#start(java.util.Map)}.
+     * {@link SourceChangesConnector#start(java.util.Map)}.
      */
     public void testStartMapOfStringString() {
         PowerMock.replayAll();
@@ -69,7 +69,7 @@ public class CloudantSourceConnectorTest extends TestCase {
 
     /**
      * Test method for
-     * {@link com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector#taskConfigs(int)}.
+     * {@link SourceChangesConnector#taskConfigs(int)}.
      */
     public void testTaskConfigs() {
         PowerMock.replayAll();

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/ValidationTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/ValidationTest.java
@@ -14,8 +14,8 @@
 
 package com.ibm.cloud.cloudant.kafka;
 
-import com.ibm.cloud.cloudant.kafka.connect.CloudantConfigValidator;
-import com.ibm.cloud.cloudant.kafka.connect.CloudantSinkConnectorConfig;
+import com.ibm.cloud.cloudant.kafka.connect.SinkConnectorConfig;
+import com.ibm.cloud.cloudant.kafka.connect.ConfigValidator;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
@@ -40,7 +40,7 @@ public class ValidationTest {
     // perform all tests against the sink config definition - the source adds a
     // few extra options but they are all booleans so don't have any fancy
     // validation
-    private final static ConfigDef CONFIG_DEF = CloudantSinkConnectorConfig.CONFIG_DEF;
+    private final static ConfigDef CONFIG_DEF = SinkConnectorConfig.CONFIG_DEF;
 
     @Test
     public void validatesBasicAuth() {
@@ -51,7 +51,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -68,7 +68,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -82,7 +82,7 @@ public class ValidationTest {
         map.put(AUTH_TYPE, "basic");
         map.put(USERNAME, "test");
         map.put(URL, "https://somewhere");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -98,7 +98,7 @@ public class ValidationTest {
         map.put(USERNAME, "test");
         map.put(PASSWORD, "");
         map.put(URL, "https://somewhere");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -113,7 +113,7 @@ public class ValidationTest {
         map.put(AUTH_TYPE, "basic");
         map.put(PASSWORD, "test");
         map.put(URL, "https://somewhere");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -129,7 +129,7 @@ public class ValidationTest {
         map.put(USERNAME, "");
         map.put(PASSWORD, "test");
         map.put(URL, "https://somewhere");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -145,7 +145,7 @@ public class ValidationTest {
         map.put(USERNAME, "test");
         map.put(PASSWORD, "test");
         map.put(URL, "https://somewhere");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -161,7 +161,7 @@ public class ValidationTest {
         map.put(USERNAME, "test");
         map.put(PASSWORD, "test");
         map.put(URL, "not-a-url");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -178,7 +178,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -193,7 +193,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -211,7 +211,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -226,7 +226,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -243,7 +243,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -258,7 +258,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -275,7 +275,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -290,7 +290,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -307,7 +307,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 
@@ -322,7 +322,7 @@ public class ValidationTest {
         map.put(URL, "https://somewhere");
         map.put(DB, "animaldb");
         map.put(TOPIC, "foo");
-        CloudantConfigValidator validator = new CloudantConfigValidator(
+        ConfigValidator validator = new ConfigValidator(
                 map,
                 CONFIG_DEF);
 

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SinkErrorTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SinkErrorTest.java
@@ -41,7 +41,7 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 
-public class CloudantSinkErrorTest {
+public class SinkErrorTest {
 
     private static final String connectionName = "_mock";
 
@@ -81,7 +81,7 @@ public class CloudantSinkErrorTest {
         // force the task to use our mock client
         ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
         // setup task with some minimal config
-        CloudantSinkTask cloudantSinkTask = new CloudantSinkTask();
+        SinkTask sinkTask = new SinkTask();
 
         Map<String, String> configMap = new HashMap<>();
         configMap.put("name", connectionName);
@@ -100,11 +100,11 @@ public class CloudantSinkErrorTest {
         //
         // when
         //
-        cloudantSinkTask.initialize(mockContext);
-        cloudantSinkTask.start(configMap);
-        cloudantSinkTask.put(Collections.singleton(sr1));
-        cloudantSinkTask.put(Collections.singleton(sr2));
-        cloudantSinkTask.flush(new HashMap<>());
+        sinkTask.initialize(mockContext);
+        sinkTask.start(configMap);
+        sinkTask.put(Collections.singleton(sr1));
+        sinkTask.put(Collections.singleton(sr2));
+        sinkTask.flush(new HashMap<>());
 
         //
         // then
@@ -136,7 +136,7 @@ public class CloudantSinkErrorTest {
         // force the task to use our mock client
         ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
         // setup task with some minimal config
-        CloudantSinkTask cloudantSinkTask = new CloudantSinkTask();
+        SinkTask sinkTask = new SinkTask();
 
         Map<String, String> configMap = new HashMap<>();
         configMap.put("name", connectionName);
@@ -153,15 +153,15 @@ public class CloudantSinkErrorTest {
         //
         // when
         //
-        cloudantSinkTask.initialize(mockContext);
-        cloudantSinkTask.start(configMap);
-        cloudantSinkTask.put(Collections.singleton(sr));
+        sinkTask.initialize(mockContext);
+        sinkTask.start(configMap);
+        sinkTask.put(Collections.singleton(sr));
 
         //
         // then
         //
         try {
-            cloudantSinkTask.flush(new HashMap<>());
+            sinkTask.flush(new HashMap<>());
             Assert.fail("ConnectException not thrown");
         } catch (ConnectException connectException) {
             Assert.assertEquals("Exception thrown when trying to write documents", connectException.getMessage());

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SinkTaskTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SinkTaskTest.java
@@ -42,9 +42,9 @@ import java.util.Map;
 /**
  * @author holger
  */
-public class CloudantSinkTaskTest extends TestCase {
+public class SinkTaskTest extends TestCase {
 
-    private CloudantSinkTask task;
+    private SinkTask task;
     private Map<String, String> targetProperties;
 
     private Map<String, Object> doc1, doc2, doc3;
@@ -58,7 +58,7 @@ public class CloudantSinkTaskTest extends TestCase {
 
         targetProperties = ConnectorUtils.getTestProperties();
 
-        task = new CloudantSinkTask();
+        task = new SinkTask();
 
         //Test objects
 
@@ -83,7 +83,7 @@ public class CloudantSinkTaskTest extends TestCase {
 
     /**
      * Test method for
-     * {@link com.ibm.cloud.cloudant.kafka.connect.CloudantSinkTask#put(java.util.Collection)}.
+     * {@link SinkTask#put(java.util.Collection)}.
      */
     public void testReplicateSinkRecordSchema() {
         List<JsonObject> result = testPutCollectionOfSinkRecord();
@@ -163,7 +163,7 @@ public class CloudantSinkTaskTest extends TestCase {
     /**
      * @return the task
      */
-    public CloudantSinkTask getTask() {
+    public SinkTask getTask() {
         return task;
     }
 

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesAndCloudantSinkTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesAndCloudantSinkTest.java
@@ -29,10 +29,10 @@ import java.util.Map;
 /**
  * @author holger
  */
-public class CloudantSourceAndSinkTest extends TestCase {
+public class SourceChangesAndCloudantSinkTest extends TestCase {
 
-    private CloudantSourceTaskTest sourceTask;
-    private CloudantSinkTaskTest sinkTask;
+    private SourceChangesTaskTest sourceTask;
+    private SinkTaskTest sinkTask;
 
     private Cloudant sourceService;
     private Cloudant targetService;
@@ -46,8 +46,8 @@ public class CloudantSourceAndSinkTest extends TestCase {
     protected void setUp() throws Exception {
         super.setUp();
 
-        sourceTask = new CloudantSourceTaskTest();
-        sinkTask = new CloudantSinkTaskTest();
+        sourceTask = new SourceChangesTaskTest();
+        sinkTask = new SinkTaskTest();
 
         sourceTask.setUp();
         sinkTask.setUp();

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesTaskTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/SourceChangesTaskTest.java
@@ -35,9 +35,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-public class CloudantSourceTaskTest extends TestCase {
+public class SourceChangesTaskTest extends TestCase {
 
-    private CloudantSourceTask task;
+    private SourceChangesTask task;
 
     private Map<String, String> sourceProperties;
 
@@ -132,7 +132,7 @@ public class CloudantSourceTaskTest extends TestCase {
             JavaCloudantUtil.batchWrite(sourceProps2, data2);
 
             // Create second connector
-            CloudantSourceTask task2 = ConnectorUtils.createCloudantSourceConnector(sourceProps2);
+            SourceChangesTask task2 = ConnectorUtils.createCloudantSourceConnector(sourceProps2);
 
             Future<List<SourceRecord>> fr1 = e.submit(new TaskCallable(task, sourceProperties));
             Future<List<SourceRecord>> fr2 = e.submit(new TaskCallable(task2, sourceProps2));
@@ -153,10 +153,10 @@ public class CloudantSourceTaskTest extends TestCase {
 
     private static final class TaskCallable implements Callable<List<SourceRecord>> {
 
-        final CloudantSourceTask t;
+        final SourceChangesTask t;
         final Map<String, String> config;
 
-        TaskCallable(CloudantSourceTask t, Map<String, String> config) {
+        TaskCallable(SourceChangesTask t, Map<String, String> config) {
             this.t = t;
             this.config = config;
         }
@@ -178,7 +178,7 @@ public class CloudantSourceTaskTest extends TestCase {
     /**
      * @return the task
      */
-    public CloudantSourceTask getTask() {
+    public SourceChangesTask getTask() {
         return task;
     }
 

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/TombstoneTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/TombstoneTest.java
@@ -69,7 +69,7 @@ public class TombstoneTest {
         // force the task to use our mock client
         ClientManagerUtils.addClientToCache(connectionName, mockCloudant);
         // setup task with some minimal config
-        CloudantSourceTask cloudantSourceTask = new CloudantSourceTask();
+        SourceChangesTask sourceChangesTask = new SourceChangesTask();
         Map<String, String> configMap = new HashMap<>();
         configMap.put("name", connectionName);
         configMap.put("cloudant.since", "1000");
@@ -85,8 +85,8 @@ public class TombstoneTest {
         replay(mockChangesResult);
         replay(mockChange);
         replay(mockChangesResultItem);
-        cloudantSourceTask.start(configMap);
-        List<SourceRecord> records = cloudantSourceTask.poll();
+        sourceChangesTask.start(configMap);
+        List<SourceRecord> records = sourceChangesTask.poll();
 
         //
         // then

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/transforms/ArrayFlattenTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/transforms/ArrayFlattenTest.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.transforms;
+package com.ibm.cloud.cloudant.kafka.connect.transforms;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
 

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/transforms/MapToStructTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/transforms/MapToStructTest.java
@@ -11,7 +11,7 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.transforms;
+package com.ibm.cloud.cloudant.kafka.connect.transforms;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.data.SchemaAndValue;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/transforms/predicates/IsDesignDocumentTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/transforms/predicates/IsDesignDocumentTest.java
@@ -11,11 +11,13 @@
  * either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-package com.ibm.cloud.cloudant.kafka.transforms.predicates;
+package com.ibm.cloud.cloudant.kafka.connect.transforms.predicates;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.util.Collections;
+
+import com.ibm.cloud.cloudant.kafka.connect.transforms.predicates.IsDesignDocument;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.DataException;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ConnectorUtils.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/connect/utils/ConnectorUtils.java
@@ -15,10 +15,10 @@ package com.ibm.cloud.cloudant.kafka.connect.utils;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.ibm.cloud.cloudant.kafka.SourceChangesConnector;
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
-import com.ibm.cloud.cloudant.kafka.connect.CloudantConnectorConfig;
-import com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector;
-import com.ibm.cloud.cloudant.kafka.connect.CloudantSourceTask;
+import com.ibm.cloud.cloudant.kafka.connect.ConnectorConfig;
+import com.ibm.cloud.cloudant.kafka.connect.SourceChangesTask;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.easymock.EasyMock;
@@ -33,9 +33,9 @@ public class ConnectorUtils {
 
     public static final String PERFORMANCE_URL = "performance.url";
 
-    public static CloudantSourceTask createCloudantSourceConnector(Map<String, String> properties) {
-        CloudantSourceConnector connector = new CloudantSourceConnector();
-        CloudantSourceTask task = new CloudantSourceTask();
+    public static SourceChangesTask createCloudantSourceConnector(Map<String, String> properties) {
+        SourceChangesConnector connector = new SourceChangesConnector();
+        SourceChangesTask task = new SourceChangesTask();
 
         ConnectorContext context = EasyMock.mock(ConnectorContext.class);
         SourceTaskContext taskContext = EasyMock.mock(SourceTaskContext.class);
@@ -116,7 +116,7 @@ public class ConnectorUtils {
         connectorProperties.put("name", "cloudant-connector-test");
 
         Collection<String> properties = new ArrayList<>();
-        properties.addAll(CloudantConnectorConfig.CONFIG_DEF.configKeys().keySet());
+        properties.addAll(ConnectorConfig.CONFIG_DEF.configKeys().keySet());
         properties.addAll(connectorProperties.keySet());
 
         // use provided values from System.getProperties (can also override defaults above)

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/performance/SinkPerformanceTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/performance/SinkPerformanceTest.java
@@ -20,7 +20,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloud.cloudant.kafka.connect.CachedClientManager;
-import com.ibm.cloud.cloudant.kafka.connect.CloudantSinkTask;
+import com.ibm.cloud.cloudant.kafka.connect.SinkTask;
 import com.ibm.cloud.cloudant.kafka.connect.utils.CloudantDbUtils;
 import com.ibm.cloud.cloudant.kafka.connect.utils.ConnectorUtils;
 import com.ibm.cloud.cloudant.v1.Cloudant;
@@ -39,14 +39,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CloudantSinkPerformanceTest extends AbstractBenchmark {
+public class SinkPerformanceTest extends AbstractBenchmark {
     private static Cloudant targetService;
     private static JsonObject testResults1 = new JsonObject();
     private static JsonObject testResults2 = new JsonObject();
     private static JsonObject testResults3 = new JsonObject();
 
     private Map<String, String> targetProperties;
-    private CloudantSinkTask sinkTask;
+    private SinkTask sinkTask;
     private List<SinkRecord> sinkRecords;
 
     @Before
@@ -62,7 +62,7 @@ public class CloudantSinkPerformanceTest extends AbstractBenchmark {
         targetService = CachedClientManager.getInstance(targetProperties);
 
         //Create Connector
-        sinkTask = new CloudantSinkTask();
+        sinkTask = new SinkTask();
 
         //Create Kafka SinkRecord
         sinkRecords = new ArrayList<>();

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/performance/SourceChangesPerformanceTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/performance/SourceChangesPerformanceTest.java
@@ -17,10 +17,10 @@ import com.carrotsearch.junitbenchmarks.AbstractBenchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.ibm.cloud.cloudant.kafka.SourceChangesConnector;
 import com.ibm.cloud.cloudant.kafka.common.InterfaceConst;
 import com.ibm.cloud.cloudant.kafka.connect.CachedClientManager;
-import com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector;
-import com.ibm.cloud.cloudant.kafka.connect.CloudantSourceTask;
+import com.ibm.cloud.cloudant.kafka.connect.SourceChangesTask;
 import com.ibm.cloud.cloudant.kafka.connect.utils.CloudantDbUtils;
 import com.ibm.cloud.cloudant.kafka.connect.utils.ConnectorUtils;
 import com.ibm.cloud.cloudant.v1.Cloudant;
@@ -35,7 +35,7 @@ import org.powermock.api.easymock.PowerMock;
 import java.util.List;
 import java.util.Map;
 
-public class CloudantSourcePerformanceTest extends AbstractBenchmark {
+public class SourceChangesPerformanceTest extends AbstractBenchmark {
     private static Cloudant sourceService;
     private static JsonObject testResults1 = new JsonObject();
     private static JsonObject testResults2 = new JsonObject();
@@ -43,7 +43,7 @@ public class CloudantSourcePerformanceTest extends AbstractBenchmark {
 
     private Map<String, String> sourceProperties;
 
-    private CloudantSourceConnector sourceConnector;
+    private SourceChangesConnector sourceConnector;
 
     @Before
     public void setUp() {
@@ -56,7 +56,7 @@ public class CloudantSourcePerformanceTest extends AbstractBenchmark {
         // Get the source database handle
         sourceService = CachedClientManager.getInstance(sourceProperties);
 
-        sourceConnector = new CloudantSourceConnector();
+        sourceConnector = new SourceChangesConnector();
         ConnectorContext context = PowerMock.createMock(ConnectorContext.class);
         sourceConnector.initialize(context);
     }
@@ -117,9 +117,9 @@ public class CloudantSourcePerformanceTest extends AbstractBenchmark {
     private long runTest() throws Exception {
         sourceConnector.start(sourceProperties);
 
-        // 1. Create Connector and Trigger sourceTask to get a batch of records
-        CloudantSourceTask sourceTask = ConnectorUtils.createCloudantSourceConnector(sourceProperties);
-        sourceTask.start(sourceProperties);
+        // 1. Create Connector and Trigger sourceChangesTask to get a batch of records
+        SourceChangesTask sourceChangesTask = ConnectorUtils.createCloudantSourceConnector(sourceProperties);
+        sourceChangesTask.start(sourceProperties);
         List<SourceRecord> records;
 
         // 2. Measure SourceRecords
@@ -127,11 +127,11 @@ public class CloudantSourcePerformanceTest extends AbstractBenchmark {
 
         do {
             // 2a. Get a batch of source records
-            records = sourceTask.poll();
+            records = sourceChangesTask.poll();
         } while (records.size() > 0);
 
-        //3. Stop sourceTask
-        sourceTask.stop();
+        //3. Stop sourceChangesTask
+        sourceChangesTask.stop();
 
         long endTime = System.currentTimeMillis();
         return endTime - startTime;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/schema/DocumentHelpers.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/schema/DocumentHelpers.java
@@ -30,7 +30,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Timestamp;
-import com.ibm.cloud.cloudant.kafka.transforms.MapToStruct;
+import com.ibm.cloud.cloudant.kafka.connect.transforms.MapToStruct;
 import com.ibm.cloud.cloudant.v1.model.Attachment;
 import com.ibm.cloud.cloudant.v1.model.Document;
 import com.ibm.cloud.cloudant.v1.model.DocumentRevisionStatus;

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -2,9 +2,9 @@
 log4j.rootLogger=ERROR, A1
 
 # Class level logging can be higher
-log4j.logger.com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnectorConfig=DEBUG
-log4j.logger.com.ibm.cloud.cloudant.kafka.connect.CloudantSourceConnector=DEBUG
-log4j.logger.com.ibm.cloud.cloudant.kafka.connect.CloudantSourceTask=DEBUG
+log4j.logger.com.ibm.cloud.cloudant.kafka.connect.SourceChangesConnectorConfig=DEBUG
+log4j.logger.com.ibm.cloud.cloudant.kafka.SourceChangesConnector=DEBUG
+log4j.logger.com.ibm.cloud.cloudant.kafka.connect.SourceChangesTask=DEBUG
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Related to #96

## Approach

Renames under the `src/main/java/com/ibm/cloud/cloudant/kafka/` path:
```
connect/CloudantSinkConnector.java -> SinkConnector.java
connect/CloudantSourceConnector.java -> SourceChangesConnector.java
connect/CloudantConfigValidator.java -> connect/ConfigValidator.java
connect/CloudantConnectorConfig.java -> connect/ConnectorConfig.java
connect/CloudantSinkConnectorConfig.java -> connect/SinkConnectorConfig.java
connect/CloudantSinkTask.java -> connect/SinkTask.java
connect/CloudantSinkTaskConfig.java -> connect/SinkTaskConfig.java
connect/CloudantSourceConnectorConfig.java -> connect/SourceChangesConnectorConfig.java
connect/CloudantSourceTask.java -> connect/SourceChangesTask.java
connect/CloudantSourceTaskConfig.java -> connect/SourceChangesTaskConfig.java
transforms/ArrayFlatten.java -> connect/transforms/ArrayFlatten.java
transforms/MapToStruct.java -> connect/transforms/MapToStruct.java
transforms/predicates/IsDesignDocument.java -> connect/transforms/predicates/IsDesignDocument.java
```

Renames under the `src/test/java/com/ibm/cloud/cloudant/kafka/` path:
```
connect/CloudantSinkConnectorTest.java -> SinkConnectorTest.java
connect/CloudantSourceConnectorTest.java -> SourceChangesConnectorTest.java
connect/CloudantSinkErrorTest.java -> connect/SinkErrorTest.java
connect/CloudantSinkTaskTest.java -> connect/SinkTaskTest.java
connect/CloudantSourceAndSinkTest.java -> connect/SourceChangesAndCloudantSinkTest.java
connect/CloudantSourceTaskTest.java -> connect/SourceChangesTaskTest.java
transforms/ArrayFlattenTest.java -> connect/transforms/ArrayFlattenTest.java
transforms/MapToStructTest.java -> connect/transforms/MapToStructTest.java
transforms/predicates/IsDesignDocumentTest.java -> connect/transforms/predicates/IsDesignDocumentTest.java
performance/CloudantSinkPerformanceTest.java -> performance/SinkPerformanceTest.java
performance/CloudantSourceAndSinkPerformanceTest.java -> performance/SourceChangesAndSinkPerformanceTest.java
performance/CloudantSourcePerformanceTest.java -> performance/SourceChangesPerformanceTest.java
```

I also refactored the references in other files to reflect the new class/file/package names.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A file rename/move changes

## Monitoring and Logging
<!--
EITHER:

The log properties changed accordingly.
