### PR TITLE
chore: tidy up ConfigDef to aid README generation

### DIFF
--- a/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/ConnectorConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/ConnectorConfig.java
@@ -33,6 +33,7 @@ public class ConnectorConfig extends AbstractConfig {
 
     protected static final String DATABASE_GROUP = "Database";
     protected static final String AUTHENTICATION_GROUP = "Authentication";
+    protected static final String KAFKA_GROUP = "Kafka";
     protected static final String AUTH_TYPE_DEFAULT = Authenticator.AUTHTYPE_IAM;
     protected static final ListRecommender VALID_AUTHS = new ListRecommender(
             Authenticator.AUTHTYPE_IAM,
@@ -79,7 +80,7 @@ public class ConnectorConfig extends AbstractConfig {
                         Type.LIST,
                         Importance.HIGH,
                         ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DOC),
-                        DATABASE_GROUP,
+                        KAFKA_GROUP,
                         order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DISP))
@@ -109,7 +110,7 @@ public class ConnectorConfig extends AbstractConfig {
                 .define(InterfaceConst.USERNAME,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_USR_DOC),
                         AUTHENTICATION_GROUP,
                         order++,
@@ -119,7 +120,7 @@ public class ConnectorConfig extends AbstractConfig {
                 .define(InterfaceConst.PASSWORD,
                         Type.PASSWORD,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_PWD_DOC),
                         AUTHENTICATION_GROUP,
                         order++,

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/ConnectorConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/ConnectorConfig.java
@@ -32,6 +32,7 @@ import java.util.Map;
 public class ConnectorConfig extends AbstractConfig {
 
     protected static final String DATABASE_GROUP = "Database";
+    protected static final String AUTHENTICATION_GROUP = "Authentication";
     protected static final String AUTH_TYPE_DEFAULT = Authenticator.AUTHTYPE_IAM;
     protected static final ListRecommender VALID_AUTHS = new ListRecommender(
             Authenticator.AUTHTYPE_IAM,
@@ -49,6 +50,8 @@ public class ConnectorConfig extends AbstractConfig {
 
     public static ConfigDef baseConfigDef() {
 
+        int order = 0;
+
         return new ConfigDef()
 
                 // Cloudant URL
@@ -59,7 +62,7 @@ public class ConnectorConfig extends AbstractConfig {
                         Importance.HIGH,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_URL_DOC),
                         DATABASE_GROUP,
-                        1,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_URL_DISP))
                 // Cloudant DB
@@ -68,17 +71,48 @@ public class ConnectorConfig extends AbstractConfig {
                         Importance.HIGH,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_DB_DOC),
                         DATABASE_GROUP,
-                        1,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_DB_DISP))
+                // Kafka topic
+                .define(InterfaceConst.TOPIC,
+                        Type.LIST,
+                        Importance.HIGH,
+                        ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DOC),
+                        DATABASE_GROUP,
+                        order++,
+                        Width.LONG,
+                        ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DISP))
+                // Cloudant auth type
+                .define(InterfaceConst.AUTH_TYPE,
+                        Type.STRING,
+                        AUTH_TYPE_DEFAULT,
+                        VALID_AUTHS,
+                        Importance.HIGH,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_AUTH_TYPE_DOC),
+                        AUTHENTICATION_GROUP,
+                        order++,
+                        Width.MEDIUM,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_AUTH_TYPE_DISP),
+                        VALID_AUTHS)
+                // Cloudant API key
+                .define(InterfaceConst.APIKEY,
+                        Type.PASSWORD,
+                        NULL_DEFAULT,
+                        Importance.HIGH,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_APIKEY_DOC),
+                        AUTHENTICATION_GROUP,
+                        order++,
+                        Width.LONG,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_APIKEY_DISP))
                 // Cloudant Username
                 .define(InterfaceConst.USERNAME,
                         Type.STRING,
                         NULL_DEFAULT,
                         Importance.HIGH,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_USR_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_USR_DISP))
                 // Cloudant Password
@@ -87,131 +121,101 @@ public class ConnectorConfig extends AbstractConfig {
                         NULL_DEFAULT,
                         Importance.HIGH,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_PWD_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_PWD_DISP))
-                // Cloudant API key
-                .define(InterfaceConst.APIKEY,
-                        Type.PASSWORD,
-                        NULL_DEFAULT,
-                        Importance.HIGH,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_APIKEY_DOC),
-                        DATABASE_GROUP,
-                        1,
-                        Width.LONG,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_APIKEY_DISP))
                 // Cloudant bearer token
                 .define(InterfaceConst.BEARER_TOKEN,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_BEARER_TOKEN_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_BEARER_TOKEN_DISP))
                 // Cloudant IAM profile id
                 .define(InterfaceConst.IAM_PROFILE_ID,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_IAM_PROFILE_ID_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_IAM_PROFILE_ID_DISP))
                 // Cloudant IAM profile name
                 .define(InterfaceConst.IAM_PROFILE_NAME,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_IAM_PROFILE_NAME_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_IAM_PROFILE_NAME_DISP))
                 // Cloudant CR token filename
                 .define(InterfaceConst.CR_TOKEN_FILENAME,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_CR_TOKEN_FILENAME_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_CR_TOKEN_FILENAME_DISP))
                 // Cloudant IAM profile CRN
                 .define(InterfaceConst.IAM_PROFILE_CRN,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_IAM_PROFILE_CRN_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_IAM_PROFILE_CRN_DISP))
                 // Cloudant auth url
                 .define(InterfaceConst.AUTH_URL,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        new UrlValidator(),
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_AUTH_URL_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_AUTH_URL_DISP))
                 // Cloudant scope
                 .define(InterfaceConst.SCOPE,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_SCOPE_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_SCOPE_DISP))
                 // Cloudant client id
                 .define(InterfaceConst.CLIENT_ID,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_CLIENT_ID_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_CLIENT_ID_DISP))
                 // Cloudant client secret
                 .define(InterfaceConst.CLIENT_SECRET,
                         Type.STRING,
                         NULL_DEFAULT,
-                        Importance.HIGH,
+                        Importance.LOW,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_CLIENT_SECRET_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        AUTHENTICATION_GROUP,
+                        order++,
                         Width.LONG,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_CLIENT_SECRET_DISP))
-                // Cloudant auth type
-                .define(InterfaceConst.AUTH_TYPE,
-                        Type.STRING,
-                        AUTH_TYPE_DEFAULT,
-                        VALID_AUTHS,
-                        Importance.HIGH,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_AUTH_TYPE_DOC),
-                        DATABASE_GROUP,
-                        1,
-                        Width.LONG,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_AUTH_TYPE_DISP),
-                        VALID_AUTHS)
-                // Kafka topic
-                .define(InterfaceConst.TOPIC,
-                        Type.LIST,
-                        Importance.HIGH,
-                        ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DOC),
-                        DATABASE_GROUP,
-                        1,
-                        Width.LONG,
-                        ResourceBundleUtil.get(MessageKey.KAFKA_TOPIC_LIST_DISP));
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_CONNECTION_CLIENT_SECRET_DISP));
     }
 
     public ConnectorConfig(ConfigDef definition, Map<?, ?> originals, boolean doLog) {

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/SinkConnectorConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/SinkConnectorConfig.java
@@ -25,6 +25,9 @@ public class SinkConnectorConfig extends ConnectorConfig {
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
     public static ConfigDef baseConfigDef() {
+
+        int order = 100; // pick a high number so these will come after those from base config def
+
         return new ConfigDef(ConnectorConfig.CONFIG_DEF)
                 // batch size
                 .define(InterfaceConst.BATCH_SIZE,
@@ -33,8 +36,8 @@ public class SinkConnectorConfig extends ConnectorConfig {
                         ConfigDef.Range.between(InterfaceConst.BATCH_SIZE_MIN_SINK, InterfaceConst.BATCH_SIZE_MAX_SINK),
                         ConfigDef.Importance.MEDIUM,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_BATCH_SIZE_SINK_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        KAFKA_GROUP,
+                        order++,
                         ConfigDef.Width.SHORT,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_BATCH_SIZE_DISP));
     }

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/SourceChangesConnectorConfig.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/tasks/SourceChangesConnectorConfig.java
@@ -28,17 +28,10 @@ public class SourceChangesConnectorConfig extends ConnectorConfig {
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
     public static ConfigDef baseConfigDef() {
+
+        int order = 100; // pick a high number so these will come after those from base config def
+
         return new ConfigDef(ConnectorConfig.CONFIG_DEF)
-                // Cloudant last change sequence
-                .define(InterfaceConst.LAST_CHANGE_SEQ,
-                        Type.STRING,
-                        LAST_SEQ_NUM_DEFAULT,
-                        Importance.LOW,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DOC),
-                        DATABASE_GROUP,
-                        1,
-                        Width.LONG,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DISP))
                 // batch size
                 .define(InterfaceConst.BATCH_SIZE,
                         Type.INT,
@@ -46,10 +39,20 @@ public class SourceChangesConnectorConfig extends ConnectorConfig {
                         ConfigDef.Range.between(InterfaceConst.BATCH_SIZE_MIN_SOURCE, InterfaceConst.BATCH_SIZE_MAX_SOURCE),
                         Importance.MEDIUM,
                         ResourceBundleUtil.get(MessageKey.CLOUDANT_BATCH_SIZE_SOURCE_DOC),
-                        DATABASE_GROUP,
-                        1,
+                        KAFKA_GROUP,
+                        order++,
                         Width.SHORT,
-                        ResourceBundleUtil.get(MessageKey.CLOUDANT_BATCH_SIZE_DISP));
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_BATCH_SIZE_DISP))
+                // Cloudant last change sequence
+                .define(InterfaceConst.LAST_CHANGE_SEQ,
+                        Type.STRING,
+                        LAST_SEQ_NUM_DEFAULT,
+                        Importance.LOW,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DOC),
+                        DATABASE_GROUP,
+                        order++,
+                        Width.LONG,
+                        ResourceBundleUtil.get(MessageKey.CLOUDANT_LAST_SEQ_NUM_DISP));
     }
 
     public SourceChangesConnectorConfig(Map<String, String> originals) {

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/validators/ListRecommender.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/validators/ListRecommender.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.config.ConfigException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 // Recommend and Validate that value must be one from a given list
 // NB matching is case insensitive for Strings
@@ -65,5 +67,10 @@ public class ListRecommender implements Recommender, Validator {
             throw new ConfigException(key, value, String.format(ResourceBundleUtil.get(MessageKey.VALIDATION_MUST_BE_ONE_OF), this.validValues));
         }
 
+    }
+
+    @Override
+    public String toString() {
+        return validValues.stream().map(Objects::toString).collect(Collectors.joining(", ", "[", "]"));
     }
 }

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/validators/UrlValidator.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/validators/UrlValidator.java
@@ -26,6 +26,10 @@ public class UrlValidator implements Validator {
 
     @Override
     public void ensureValid(String name, Object value) {
+        // can be null if it's optional
+        if (value == null) {
+            return;
+        }
         if (value instanceof URL) {
             return;
         }
@@ -39,5 +43,10 @@ public class UrlValidator implements Validator {
             return;
         }
         throw new ConfigException(name, value, String.format(ResourceBundleUtil.get(MessageKey.VALIDATION_NOT_A_URL), value));
+    }
+
+    @Override
+    public String toString() {
+        return "<any URL>";
     }
 }

--- a/src/main/resources/message_en_US.properties
+++ b/src/main/resources/message_en_US.properties
@@ -1,5 +1,5 @@
 CloudantConnectUrlDisp = Database connection
-CloudantConnectUrlDoc = Cloudant database connection URL (eg https://<uuid>.cloudantnosqldb.appdomain.cloud)
+CloudantConnectUrlDoc = Cloudant database connection URL (eg `https://<uuid>.cloudantnosqldb.appdomain.cloud`)
 
 CloudantConnectDbDisp = Database name
 CloudantConnectDbDoc = Cloudant database name (for sink connector it will be created if it does not exist)

--- a/src/main/resources/message_en_US.properties
+++ b/src/main/resources/message_en_US.properties
@@ -45,11 +45,7 @@ CloudantConnectApikeyDoc = Cloudant database IAM API key, for use with "iam" aut
 
 CloudantLastSeqNumDoc = Last update sequence identifier to resume from. \
 	Identified sequence number is included in the result set. \
-	See "last_seq" parameter in Cloudant _changes API documentation for details. \
-	(example: 1-g1AAAAI9eJyV0EsKwjAUBdD4Ad2FdQMlMW3TjOxONF9KqS1oHDjSnehOdCe6k5oQsNZBqZP3Hi\
-	EcLrcEAMzziQSB5KLeq0zyJDTqYE4QJqEo66NklQkrZUr7c8wAXzRNU-T22tmHGVMUapR2Bdwj8MBOvu4gscQyU\
-	tghyw-CYJ-SOWXTUSJMkKQ_UWgfsnXIuYOkhCCN6PBGqqmd4GKXda4OGvk0VCcCweHFeOjmoXubiEREIyb-KMdL\
-	Dy89W4nTVGkqhhfkoZeHvkrimMJYrYo31bKsIg)
+	See "last_seq" parameter in Cloudant _changes API documentation for details.
 CloudantLastSeqNumDisp = Last sequence number
 
 CloudantBatchSizeDisp = Batch size


### PR DESCRIPTION
fixes #111

Open questions (see output below for reference):
- Is importance level correct for each?
- Is order correct?
- Do batch size, topics and starting sequence belong under "database" group?

Here is the RST output for the Sink Connector:
```
Database
^^^^^^^^

``cloudant.url``
  Cloudant database connection URL (eg https://<uuid>.cloudantnosqldb.appdomain.cloud)

  * Type: string
  * Valid Values: <any URL>
  * Importance: high

``cloudant.db``
  Cloudant database name (for sink connector it will be created if it does not exist)

  * Type: string
  * Importance: high

``batch.size``
  Size of batches to send to Cloudant _bulk_docs endpoint

  * Type: int
  * Default: 1000
  * Valid Values: [1,...,20000]
  * Importance: medium

``topics``
  Kafka topic list

  * Type: list
  * Importance: high

Authentication
^^^^^^^^^^^^^^

``cloudant.auth.type``
  Cloudant authentication method (or type)

  * Type: string
  * Default: iam
  * Valid Values: [iam, couchdb_session, basic, noauth, bearertoken, container, vpc]
  * Importance: high

``cloudant.apikey``
  Cloudant database IAM API key, for use with "iam" authentication

  * Type: password
  * Default: null
  * Importance: high

``cloudant.username``
  Cloudant username, for use with "couchdb_session" or "basic" authentication

  * Type: string
  * Default: null
  * Importance: high

``cloudant.password``
  Cloudant password, for use with "couchdb_session" or "basic" authentication

  * Type: password
  * Default: null
  * Importance: high

``cloudant.bearer.token``
  Cloudant bearer token, for use with "bearerToken" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.iam.profile.id``
  Cloudant IAM profile ID, for use with "container" or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.iam.profile.name``
  Cloudant IAM profile name, for use with "container" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.cr.token.filename``
  Cloudant CR token filename, for use with "container" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.iam.profile.crn``
  Clouant IAM profile CRN, for use with "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.auth.url``
  Cloudant auth URL, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Valid Values: <any URL>
  * Importance: low

``cloudant.scope``
  Cloudant scope, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.client.id``
  Cloudant client ID, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.client.secret``
  Cloudant client secret, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low
```

and for the source:

```
Database
^^^^^^^^

``cloudant.url``
  Cloudant database connection URL (eg https://<uuid>.cloudantnosqldb.appdomain.cloud)

  * Type: string
  * Valid Values: <any URL>
  * Importance: high

``cloudant.db``
  Cloudant database name (for sink connector it will be created if it does not exist)

  * Type: string
  * Importance: high

``batch.size``
  Size of batches to retrieve from Cloudant _changes endpoint

  * Type: int
  * Default: 1000
  * Valid Values: [1,...,20000]
  * Importance: medium

``cloudant.since``
  Last update sequence identifier to resume from. Identified sequence number is included in the result set. See "last_seq" parameter in Cloudant _changes API documentation for details. (example: 1-g1AAAAI9eJyV0EsKwjAUBdD4Ad2FdQMlMW3TjOxONF9KqS1oHDjSnehOdCe6k5oQsNZBqZP3HiEcLrcEAMzziQSB5KLeq0zyJDTqYE4QJqEo66NklQkrZUr7c8wAXzRNU-T22tmHGVMUapR2Bdwj8MBOvu4gscQyUtghyw-CYJ-SOWXTUSJMkKQ_UWgfsnXIuYOkhCCN6PBGqqmd4GKXda4OGvk0VCcCweHFeOjmoXubiEREIyb-KMdLDy89W4nTVGkqhhfkoZeHvkrimMJYrYo31bKsIg)

  * Type: string
  * Default: 0
  * Importance: low

``topics``
  Kafka topic list

  * Type: list
  * Importance: high

Authentication
^^^^^^^^^^^^^^

``cloudant.auth.type``
  Cloudant authentication method (or type)

  * Type: string
  * Default: iam
  * Valid Values: [iam, couchdb_session, basic, noauth, bearertoken, container, vpc]
  * Importance: high

``cloudant.apikey``
  Cloudant database IAM API key, for use with "iam" authentication

  * Type: password
  * Default: null
  * Importance: high

``cloudant.username``
  Cloudant username, for use with "couchdb_session" or "basic" authentication

  * Type: string
  * Default: null
  * Importance: high

``cloudant.password``
  Cloudant password, for use with "couchdb_session" or "basic" authentication

  * Type: password
  * Default: null
  * Importance: high

``cloudant.bearer.token``
  Cloudant bearer token, for use with "bearerToken" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.iam.profile.id``
  Cloudant IAM profile ID, for use with "container" or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.iam.profile.name``
  Cloudant IAM profile name, for use with "container" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.cr.token.filename``
  Cloudant CR token filename, for use with "container" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.iam.profile.crn``
  Clouant IAM profile CRN, for use with "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.auth.url``
  Cloudant auth URL, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Valid Values: <any URL>
  * Importance: low

``cloudant.scope``
  Cloudant scope, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.client.id``
  Cloudant client ID, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low

``cloudant.client.secret``
  Cloudant client secret, for use with "iam", "container", or "vpc" authentication

  * Type: string
  * Default: null
  * Importance: low
```