### PR TITLE
fix: convert LazilyParsedNumbers to specific Number types

### DIFF
--- a/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentToSourceRecord.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentToSourceRecord.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.source.SourceRecord;
 import com.ibm.cloud.cloudant.kafka.utils.CloudantConst;
+import com.ibm.cloud.cloudant.kafka.utils.NumberSafeMap;
 import com.ibm.cloud.cloudant.v1.model.ChangesResultItem;
 import com.ibm.cloud.cloudant.v1.model.Document;
 
@@ -86,7 +87,7 @@ public class DocumentToSourceRecord implements BiFunction<String, ChangesResultI
     Map<String, Object> documentToMap(Document document) {
         Map<String, Object> fixedProperties = getFixedProperties(document);
         Map<String, Object> dynamicProperties = Collections.unmodifiableMap(document.getProperties());
-        Map<String, Object> map = new HashMap<>(fixedProperties.size() + dynamicProperties.size());
+        Map<String, Object> map = new NumberSafeMap(fixedProperties.size() + dynamicProperties.size());
         map.putAll(fixedProperties);
         map.putAll(dynamicProperties);
         return Collections.unmodifiableMap(map);

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/utils/NumberSafeMap.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/utils/NumberSafeMap.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2022 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.ibm.cloud.cloudant.kafka.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * An extension of HashMap that converts Number type entries being added to the Map.
+ * It recurses into Collections being added to ensure their Number values are also converted.
+ * 
+ * The principle is that the string value of a number is converted to a BigDecimal that can
+ * hold arbitrary precision values. Then it attempts to narrow down to the most specific Number
+ * type that can hold the value. This means that any use in a schema later can easily widen the
+ * value without losing precision, whereas returning a wider type might cause narrow schema
+ * types to fail.
+ * 
+ * Values without float content are preferentially converted to whole number types because the max
+ * of Integer (2^32 -1) exceeds that of the set of integers fully representable in Float (2^24)
+ * and Long (2^64 -1) exceeds that of Double (2^53). This makes it worth noting that
+ * Float.MAX_VALUE or Double.MAX_VALUE will be converted to BigInteger
+ * (since the value exceeds that representable by Long), but those floating point max values
+ * cannot represent all integer values lower than them.
+ */
+public class NumberSafeMap extends HashMap<String, Object> {
+
+    private static final NumberMapper mapper = new NumberMapper();
+
+    public NumberSafeMap() {
+        super();
+    }
+
+    public NumberSafeMap(int length) {
+        super(length);
+    }
+
+    public NumberSafeMap(Map<String, Object> map) {
+        this(map.size());
+        this.putAll(map);
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        return super.put(key, value != null ? mapper.apply(value): value);
+    }
+
+    @Override
+    public void putAll(Map<?  extends String, ? extends Object> m) {
+        m.forEach((k, v) -> this.put(k, v));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final class NumberMapper implements UnaryOperator<Object> {
+
+        // A list of the preference order by which we try to narrow the value into a specific Number type.
+        private static final List<Function<BigDecimal, ? extends Number>> narrowingFunctions = Collections.unmodifiableList(
+            Arrays.asList(
+                BigDecimal::byteValueExact,
+                BigDecimal::shortValueExact,
+                BigDecimal::intValueExact,
+                BigDecimal::longValueExact,
+                BigDecimal::toBigIntegerExact,
+                (n) -> {
+                    float f = n.floatValue();
+                    if (f != Float.NEGATIVE_INFINITY && f != Float.POSITIVE_INFINITY && n.equals(new BigDecimal(f))) {
+                        // Exactly representable by float
+                        return f;
+                    } else {
+                        throw new ArithmeticException();
+                    }
+                },
+                (n) -> n.doubleValue() // Last resort is a double value, noting that CouchDB/Cloudant JSON source numbers are limited to IEEE754 doubles
+                ));
+
+        @Override
+        public Object apply(Object value) {
+            // The underlying client SDK uses GSON's LazilyParsedNumber.
+            // These are incompatible with the Kafka JsonConverter so we
+            // need to change them to a built-in Number type.
+            // Leave BigInteger and BigDecimal as is
+            if (value instanceof Number && !(value instanceof BigInteger || value instanceof BigDecimal)) {
+                // Make a BigDecimal from the Number as it can hold the values of all other types
+                BigDecimal number = new BigDecimal(value.toString());
+                for (Function<BigDecimal, ? extends Number> narrowingFunction : narrowingFunctions) {
+                    try{
+                        return narrowingFunction.apply(number);
+                    } catch(ArithmeticException n) {
+                        // The narrowing function was not suitable, try the next one.
+                        continue;
+                    }
+                }
+                // The last resort narrowing function should always return a double so this code should be unreachable.
+                // In case the list of narrowing functions changes without updating this code, fallback
+                // to returning the BigDecimal value of arbitrary precision.
+                return number;
+            } else if (value instanceof Map) {
+                return new NumberSafeMap((Map<String, Object>) value);
+            } else if (value instanceof List) {
+                // Make a new list instead of doing direct replacement
+                // just in case the original is unmodifiable.
+                List<Object> numberSafeList = new ArrayList<>(((List<Object>) value));
+                numberSafeList.replaceAll(mapper);
+                return numberSafeList;
+            } else {
+                return value;
+            }
+        }
+    }
+}

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentHelpers.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentHelpers.java
@@ -47,7 +47,7 @@ public class DocumentHelpers {
         BOOLEAN(true),
         BYTES(new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE}),
         DATE(Date.from(Instant.now()), v -> Timestamp.builder().optional().build()),
-        FLOAT32(Float.MAX_VALUE),
+        FLOAT32(Float.valueOf("4194304.5")), // 2^22 + 0.5 (An exact float since between 2^22 and 2^23 precision limit is 0.5)
         FLOAT64(Double.MIN_VALUE),
         INT16(Short.MAX_VALUE),
         INT32(Integer.MIN_VALUE),

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/utils/NumberSafeMapTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/utils/NumberSafeMapTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright © 2022 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.ibm.cloud.cloudant.kafka.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.google.gson.internal.LazilyParsedNumber;
+
+public class NumberSafeMapTest {
+
+    private static final String testKey = "test";
+    private static JsonConverter converter = new JsonConverter();
+
+    @BeforeClass
+    public static void configure() {
+        converter.configure(Collections.singletonMap("schemas.enable", false), false);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        converter.close();
+    }
+
+    private <T> Map<String, Object> makeMap(String valueAsString) {
+        Map<String, Object> map = new NumberSafeMap();
+        map.put(testKey, new LazilyParsedNumber(valueAsString));
+        return map;
+    }
+    
+    private <T> void assertExpectedType(Map<String, Object> map, Class<T> expectedType) {   
+        Object o = map.get(testKey);
+        assertEquals("The value should be of the expected type.", expectedType, o.getClass());
+    }
+
+    private void convert(Map<String, Object> map) {
+        converter.fromConnectData("test", null, map);
+    }
+
+    @Test
+    public void testByteNumberMin() {
+        Map<String, Object> testMap = makeMap(Byte.toString(Byte.MIN_VALUE));
+        assertExpectedType(testMap, Byte.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testByteNumber() {
+        Map<String, Object> testMap = makeMap("3");
+        assertExpectedType(testMap, Byte.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testByteNumberMax() {
+        Map<String, Object> testMap = makeMap(Byte.toString(Byte.MAX_VALUE));
+        assertExpectedType(testMap, Byte.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testShortNumberMin() {
+        Map<String, Object> testMap = makeMap(Short.toString(Short.MIN_VALUE));
+        assertExpectedType(testMap, Short.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testShortNumber() {
+        Map<String, Object> testMap = makeMap("128");
+        assertExpectedType(testMap, Short.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testShortNumberMax() {
+        Map<String, Object> testMap = makeMap(Short.toString(Short.MAX_VALUE));
+        assertExpectedType(testMap, Short.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testIntegerNumberMin() {
+        Map<String, Object> testMap = makeMap(Integer.toString(Integer.MIN_VALUE));
+        assertExpectedType(testMap, Integer.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testIntegerNumber() {
+        Map<String, Object> testMap = makeMap(Integer.valueOf(Short.MAX_VALUE + 1).toString());
+        assertExpectedType(testMap, Integer.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testIntegerNumberMax() {
+        Map<String, Object> testMap = makeMap(Integer.toString(Integer.MAX_VALUE));
+        assertExpectedType(testMap, Integer.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testLongNumberMin() {
+        Map<String, Object> testMap = makeMap(Long.toString(Long.MIN_VALUE));
+        assertExpectedType(testMap, Long.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testLongNumber() {
+        Map<String, Object> testMap = makeMap(Long.toString(Integer.MAX_VALUE + 1L));
+        assertExpectedType(testMap, Long.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testLongNumberMax() {
+        Map<String, Object> testMap = makeMap(Long.toString(Long.MAX_VALUE));
+        assertExpectedType(testMap, Long.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testFloatNumberMin() {
+        Map<String, Object> testMap = makeMap(new BigDecimal(Float.MIN_VALUE).negate().toString());
+        assertExpectedType(testMap, Float.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testFloatNumber() {
+        Map<String, Object> testMap = makeMap("0.125");
+        assertExpectedType(testMap, Float.class);
+        convert(testMap);
+    }
+
+    /**
+     * Test a Float at extreme range.
+     * Note that Float.MAX_VALUE is an integer, and if specified
+     * will return a BigInteger.
+     */
+    @Test
+    public void testFloatNormalNumber() {
+        Map<String, Object> testMap = makeMap(new BigDecimal(Float.MIN_NORMAL).toString());
+        assertExpectedType(testMap, Float.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testDoubleNumberMin() {
+        Map<String, Object> testMap = makeMap(new BigDecimal(Double.MIN_VALUE).toString());
+        assertExpectedType(testMap, Double.class);
+        convert(testMap);
+    }
+
+    @Test
+    public void testDoubleNumber() {
+        Map<String, Object> testMap = makeMap(new BigDecimal(Math.PI).toString());
+        assertExpectedType(testMap, Double.class);
+        convert(testMap);
+    }
+
+    /**
+     * Test a Double at extreme range.
+     * Note that Double.MAX_VALUE is an integer, and if specified
+     * will return a BigInteger.
+     */
+    @Test
+    public void testDoubleNormalNumber() {
+        Map<String, Object> testMap = makeMap(new BigDecimal(Double.MIN_NORMAL).toString());
+        assertExpectedType(testMap, Double.class);
+        convert(testMap);
+    }
+
+    /**
+     * Validate that we leave BigIntegers as BigIntegers.
+     * Note they are not supported by the Kafka JsonConverter.
+     */
+    @Test
+    public void testBigInteger() {
+        Map<String, Object> testMap = new NumberSafeMap();
+        testMap.put(testKey, BigInteger.TEN);
+        assertExpectedType(testMap, BigInteger.class);
+    }
+
+    /**
+     * Validate that we leave BigDecimals as BigDecimals
+     * Note they are not supported by the Kafka JsonConverter.
+     */
+    @Test
+    public void testBigDecimal() {
+        Map<String, Object> testMap = new NumberSafeMap();
+        testMap.put(testKey, BigDecimal.ONE);
+        assertExpectedType(testMap, BigDecimal.class);
+    }
+
+    /**
+     * Validate that null entries don't cause NPEs.
+     */
+    @Test
+    public void testNullValue() {
+        Map<String, Object> testMap = new NumberSafeMap();
+        testMap.put(testKey, (Number) null);
+        assertNull(testMap.get(testKey));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testNumberNestedInMap() {
+        Map<String, Object> nestedMap = Collections.singletonMap(testKey, new LazilyParsedNumber("17"));
+        Map<String, Object> testMap = new NumberSafeMap();
+        testMap.put("nested", nestedMap);
+        Map<String, Object> actualNested = (Map<String, Object>) testMap.get("nested");
+        assertNotNull("The nested map should not be null.", actualNested);
+        assertExpectedType(actualNested, Byte.class);
+        convert(testMap);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testNumberNestedInArray() {
+        List<LazilyParsedNumber> nestedList = Collections.singletonList(new LazilyParsedNumber("17"));
+        Map<String, Object> testMap = new NumberSafeMap();
+        testMap.put("nested", nestedList);
+        List<Object> actualNested = (List<Object>) testMap.get("nested");
+        assertNotNull("The nested list should not be null.", actualNested);
+        assertFalse("The nested list should not be empty.", actualNested.isEmpty());
+        assertEquals("The nested list should have one element.", 1, actualNested.size());
+        assertEquals("The value should be of the expected type.", Byte.class, actualNested.get(0).getClass());
+        convert(testMap);
+    }
+
+    /**
+     * Checks a Number in a Map in a List in a Map in a Map.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testNumberInDeeperNesting() {
+        String value = "255";
+        Short expectedValue = Short.valueOf(value);
+        Map<String, Object> sourceMap = Collections.singletonMap("outer", 
+            Collections.singletonMap("list",
+                Collections.singletonList(
+                    Collections.singletonMap(testKey, new LazilyParsedNumber(value)))));
+        NumberSafeMap actualMap = new NumberSafeMap(sourceMap);
+        Map<String, Object> outer = (Map<String, Object>) actualMap.get("outer");
+        assertNotNull("The outer map should not be null.", outer);
+        List<Object> list = (List<Object>) outer.get("list");
+        assertNotNull("The nested list should not be null.", list);
+        assertFalse("The nested list should not be empty.", list.isEmpty());
+        assertEquals("The nested list should have one element.", 1, list.size());
+        Map<String, Object> inner = (Map<String, Object>) list.get(0);
+        assertNotNull("The inner map should not be null.", inner);
+        Object testNumber = inner.get(testKey);
+        assertNotNull("The entry should not be null.", testNumber);
+        assertEquals("The value should be of the expected type.", expectedValue.getClass(), testNumber.getClass());
+        assertEquals("The value should be correct.", expectedValue, testNumber);
+        convert(actualMap);
+    }
+
+}


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Convert GSON's LazilyParsedNumbers into specific Number types so that they are compatible with Kafka converters.

Fixes #112 

## Approach

Change the `DocumentToSourceRecord` mapper to use a new `NumberSafeMap` that converts instances of `Number` into the narrowest possible type.
There is a concious decision here to not just use `Long` or `Double` to maintain the widest possible compatibility with Kafka connect types (e.g. `Int8`, `Int16` etc). It is easier to accept narrower values into wider ones (e.g. `Int8` -> `Int32` than it is to do the opposite).

There is additional detail about the behaviour in the javadoc of the `NumberSafeMap` class.

Currently the type of last resort is `double` - I am awaiting validation from CouchDB that this is in fact the highest precision available in the source JSON documents.

## Schema & API Changes

- Changes the types of `Number` present in SourceRecord values. This is not a breaking change it is currently unreleased code.

## Security and Privacy

- "No change"

## Testing

- Added new tests `NumberSafeMapTest` that cover a wide range of number types in the map and running the `JsonConverter` on the result.
- Existing `DocumentToSourceRecord.testDocumentWithEverything` also covers this code and a `float` value was adjusted to meet the new expectations and avoid conversion to a `double`.


## Monitoring and Logging

- "No change"
