### PR TITLE
refactor: source partition offset map

### DIFF
--- a/src/test/java/com/ibm/cloud/cloudant/kafka/tasks/SourceChangesTaskTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/tasks/SourceChangesTaskTest.java
@@ -16,7 +16,6 @@ package com.ibm.cloud.cloudant.kafka.tasks;
 import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.ibm.cloud.cloudant.kafka.utils.CloudantConst;
@@ -28,7 +27,6 @@ import com.ibm.cloud.cloudant.kafka.utils.ConnectorUtils;
 import junit.framework.TestCase;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.powermock.api.easymock.PowerMock;
-
 import java.io.FileReader;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 public class SourceChangesTaskTest extends TestCase {
 
@@ -88,7 +87,50 @@ public class SourceChangesTaskTest extends TestCase {
         assertNotNull(firstValue);
         assertNotNull(firstValue.get(CloudantConst.CLOUDANT_DOC_ID));
         assertNotNull(firstValue.get(CloudantConst.CLOUDANT_REV));
+    }
 
+    public void testSourcePartitionAndOffsetMaps() throws InterruptedException {
+        PowerMock.replayAll();
+
+        // Run the task and process all documents currently in the _changes feed
+        task.start(sourceProperties);
+        List<SourceRecord> records = task.poll();
+        assertTrue("There should be at least two records.", records.size() >= 2);
+
+        // Get the first record
+        SourceRecord firstRecord = records.get(0);
+        assertNotNull(firstRecord);
+
+        // Partition map
+        Map<String, ?> sourcePartition = firstRecord.sourcePartition();
+        assertNotNull("The source partition should not be null.", sourcePartition);
+        assertEquals("There should be two entries in the map.", 2, sourcePartition.size());
+        // URL entry
+        assertEquals("The URL entry should match the config.", sourceProperties.get(InterfaceConst.URL), 
+                sourcePartition.get(InterfaceConst.URL));
+        // DB entry
+        assertEquals("The DB entry should match the config.", sourceProperties.get(InterfaceConst.DB), 
+                sourcePartition.get(InterfaceConst.DB));
+
+        // Offset map
+        Map<String, ?> sourceOffset = firstRecord.sourceOffset();
+        assertNotNull("The offset should not be null.", sourceOffset);
+        assertEquals("There should be one entry in the map.", 1, sourceOffset.size());
+        Object sourceOffsetSeq = sourceOffset.get(InterfaceConst.LAST_CHANGE_SEQ);
+        assertNotNull("The offset seq entry should not be null.", sourceOffsetSeq);
+        String offsetSeq = String.valueOf(sourceOffsetSeq);
+        assertTrue(String.format("The offset seq %s should match a seq pattern.", offsetSeq),
+                Pattern.matches("\\d+-[A-Za-z0-9_-]+", offsetSeq));
+
+        // Assert that first and second record partitions are the same, but offsets different
+        // Get the second record
+        SourceRecord secondRecord = records.get(1);
+        assertNotNull(secondRecord);
+        assertEquals("The first and second records should have the same source partition.",
+                firstRecord.sourcePartition(),
+                secondRecord.sourcePartition());
+        assertFalse("The first and second records should have different offsets.",
+                firstRecord.sourceOffset().equals(secondRecord.sourceOffset()));
     }
 
     public void testStartWithIncrementalUpdates() throws InterruptedException {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Refactor source partiton offset map.

Fixes #107

## Approach

Replace the concatenated string offset with a Map containing two entries, one for the URL and one for the DB.
Re-use the existing constants for `cloudant.url` and `cloudant.db` as keys.
Remove unnecessary `offset` method and populate the `sourcePartition` map during `start`.

## Schema & API Changes

- Internal change to offset Map format, no external change.

## Security and Privacy

- "No change"

## Testing

- Added new test `SourceChangesTaskTest#testSourcePartitionAndOffsetMaps()` to validate correct partition and offset entries.

## Monitoring and Logging

- "No change"
