### PR TITLE
fix: ensure collection (array/list) types are converted properly

### DIFF
--- a/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/SinkRecordToDocument.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/SinkRecordToDocument.java
@@ -21,10 +21,12 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class SinkRecordToDocument implements Function<SinkRecord, Document> {
 
@@ -41,6 +43,7 @@ public class SinkRecordToDocument implements Function<SinkRecord, Document> {
             return Collections.emptyMap();
         }
         // we can convert from a struct or a map - assume a map when a value schema is not provided
+        // NB arrays not supported at top level - they are not valid json
         Schema.Type schemaType = record.valueSchema() == null ? Schema.Type.MAP : record.valueSchema().type();
         Map<String, Object> toReturn = new HashMap<>();
         switch (schemaType) {
@@ -78,7 +81,7 @@ public class SinkRecordToDocument implements Function<SinkRecord, Document> {
         // iterate fields and add to map
         for (Field f : schema.fields()) {
             Object value = struct.get(f);
-            outMap.put(f.name(), getField(f.schema().type(), value));
+            outMap.put(f.name(), convertItemFromStruct(f.schema().type(), value));
         }
         return outMap;
     }
@@ -86,17 +89,11 @@ public class SinkRecordToDocument implements Function<SinkRecord, Document> {
     // convert kafka map to map by adding key/values to passed in map, and returning it
     private Map<String, Object> convertMap(Map<?,?> inMap, Map<String, Object> outMap) {
 
+        // iterate over keys and add to map
         for (Object k : inMap.keySet()) {
             if (k instanceof String) {
                 Object v = inMap.get(k);
-                if (v instanceof Map) {
-                    outMap.put((String) k, convertMap((Map<?,?>) v, new HashMap<>()));
-                } else if (v instanceof Struct) {
-                    outMap.put((String) k, convertStruct((Struct) v, new HashMap<>()));
-                } else {
-                    // assume that JSON serialiser knows how to deal with it
-                    outMap.put((String) k, v);
-                }
+                outMap.put((String) k, convertItem(v));
             } else {
                 throw new IllegalArgumentException("unsupported type in map key " + k.getClass());
             }
@@ -104,12 +101,17 @@ public class SinkRecordToDocument implements Function<SinkRecord, Document> {
         return outMap;
     }
 
+    // could be an array, list, or collection: convert each item in turn and return list
+    private Collection<?> convertCollection(Collection<?> c) {
+        return c.stream().map(this::convertItem).collect(Collectors.toList());
+    }
+
+    // helper for convertStruct
     // get field value, recursing if necessary for struct types
-    private Object getField(Type type, Object value) {
+    private Object convertItemFromStruct(Type type, Object value) {
 
         switch (type) {
             // primitive types: just return value (JSON serialiser will deal with conversion later)
-            case ARRAY:
             case BOOLEAN:
             case BYTES:
             case FLOAT32:
@@ -125,10 +127,27 @@ public class SinkRecordToDocument implements Function<SinkRecord, Document> {
                 return convertMap((Map<?,?>) value, new HashMap<>());
             case STRUCT:
                 return convertStruct((Struct) value, new HashMap<>());
+            // array case:
+            case ARRAY:
+                return convertCollection((Collection<?>) value);
             default:
                 throw new IllegalArgumentException("unknown type " + type);
         }
 
+    }
+
+    // helper for convertMap, convertCollection
+    private Object convertItem(Object value) {
+        if (value instanceof Map) {
+            return convertMap((Map<?,?>) value, new HashMap<>());
+        } else if (value instanceof Struct) {
+            return convertStruct((Struct) value, new HashMap<>());
+        } else if (value instanceof Collection) {
+            return convertCollection((Collection<?>) value);
+        } else {
+            // assume that JSON serialiser knows how to deal with it
+            return value;
+        }
     }
 
     private String getHeaderForDocId(SinkRecord record) {

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/SinkRecordToDocument.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/SinkRecordToDocument.java
@@ -90,12 +90,11 @@ public class SinkRecordToDocument implements Function<SinkRecord, Document> {
     private Map<String, Object> convertMap(Map<?,?> inMap, Map<String, Object> outMap) {
 
         // iterate over keys and add to map
-        for (Object k : inMap.keySet()) {
-            if (k instanceof String) {
-                Object v = inMap.get(k);
-                outMap.put((String) k, convertItem(v));
+        for (Map.Entry<?, ?> entry : inMap.entrySet()) {
+            if (entry.getKey() instanceof String) {
+                outMap.put((String) entry.getKey(), convertItem(entry.getValue()));
             } else {
-                throw new IllegalArgumentException("unsupported type in map key " + k.getClass());
+                throw new IllegalArgumentException("unsupported type in map key " + entry.getKey().getClass());
             }
         }
         return outMap;

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/mappers/SinkRecordToDocumentTests.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/mappers/SinkRecordToDocumentTests.java
@@ -165,7 +165,6 @@ public class SinkRecordToDocumentTests {
 
     }
 
-    // TODO test for array of structs
     @SuppressWarnings("unchecked")
     @Test
     public void testConvertArrayOfStructs() {
@@ -186,21 +185,20 @@ public class SinkRecordToDocumentTests {
         list.add(listValue2);
         value.put("struct_array", list);
 
-        // do conversion
-        SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
-        Document converted = mapper.apply(sr);
-
-
-        System.out.println(s);
-        assertEquals(((List<Map<String, Object>>) converted.get("struct_array")).get(0).get("string"), "foo1");
-        assertEquals(((List<Map<String, Object>>) converted.get("struct_array")).get(1).get("string"), "foo2");
-
         // when...
         try {
             value.validate();
         } catch (DataException de) {
             fail("Data invalid according to schema");
         }
+
+        // do conversion
+        SinkRecord sr = new SinkRecord("test", 13, null, "0001", s, value, 0);
+        Document converted = mapper.apply(sr);
+
+        // then...
+        assertEquals(((List<Map<String, Object>>) converted.get("struct_array")).get(0).get("string"), "foo1");
+        assertEquals(((List<Map<String, Object>>) converted.get("struct_array")).get(1).get("string"), "foo2");
     }
 
     @Test


### PR DESCRIPTION
fixes #116

NB original issue was incorrect, nested structs are handled (see `testConvertComplexStruct`), but collection/list/array types were not always correctly handled.