### PR TITLE
feat: change record key to struct including url and db

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For the source connector:
   * `cloudant.url`: the URL of the Cloudant instance the event originated from.
 * Values are produced as a (schemaless) `java.util.Map<String, Object>`.
 * These types are compatible with the default `org.apache.kafka.connect.json.JsonConverter` and should be compatible with any other converter that can accept a `Struct` or `Map`.
-* The `schemas.enabled` may be safely used with a `key.converter` if desired.
+* The `schemas.enable` may be safely used with a `key.converter` if desired.
 * The source connector does not generate schemas for the record values by default. To use `schemas.enable` with the `value.converter` consider using a schema registry or the [`MapToStruct` SMT](docs/smt-reference.md#map-to-struct-conversion).
 
 #### Converter Configuration: sink connector

--- a/README.md
+++ b/README.md
@@ -109,9 +109,12 @@ For instance, in the sample configuration files, value schemas are disabled on t
 #### Converter Configuration: source connector
 
 For the source connector:
-* Keys are produced as `java.util.Map<String, String>` containing an `_id` entry with the original Cloudant document ID.
+* Keys are produced as a `org.apache.kafka.connect.data.Struct` containing:
+  * `_id`: the original Cloudant document ID
+  * `cloudant.db`: the name of the Cloudant database the event originated from
+  * `cloudant.url`: the URL of the Cloudant instance the event originated from.
 * Values are produced as a (schemaless) `java.util.Map<String, Object>`.
-* These types are compatible with the default `org.apache.kafka.connect.json.JsonConverter` and should be compatible with any other converter that can accept a `Map`.
+* These types are compatible with the default `org.apache.kafka.connect.json.JsonConverter` and should be compatible with any other converter that can accept a `Struct` or `Map`.
 * The `schemas.enabled` may be safely used with a `key.converter` if desired.
 * The source connector does not generate schemas for the record values by default. To use `schemas.enable` with the `value.converter` consider using a schema registry or the [`MapToStruct` SMT](docs/smt-reference.md#map-to-struct-conversion).
 

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentToSourceRecord.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentToSourceRecord.java
@@ -82,16 +82,16 @@ public class DocumentToSourceRecord implements BiFunction<String, ChangesResultI
 
     @Override
     public SourceRecord apply(String topic, ChangesResultItem changesResultItem) {
-        return new SourceRecord(partition, 
-        offsetFunction.apply(changesResultItem.getSeq()),
-        topic,
-        RECORD_KEY_SCHEMA,
-        new Struct(RECORD_KEY_SCHEMA)
-                .put(CloudantConst.CLOUDANT_DOC_ID, changesResultItem.getId())
-                .put(InterfaceConst.DB, partition.get(InterfaceConst.DB))
-                .put(InterfaceConst.URL, partition.get(InterfaceConst.URL)),
+        return new SourceRecord(partition,
+                offsetFunction.apply(changesResultItem.getSeq()),
+                topic,
+                RECORD_KEY_SCHEMA,
+                new Struct(RECORD_KEY_SCHEMA)
+                        .put(CloudantConst.CLOUDANT_DOC_ID, changesResultItem.getId())
+                        .put(InterfaceConst.DB, partition.get(InterfaceConst.DB))
+                        .put(InterfaceConst.URL, partition.get(InterfaceConst.URL)),
                 RECORD_VALUE_SCHEMA,
-        documentToMap(changesResultItem.getDoc()));
+                documentToMap(changesResultItem.getDoc()));
     }
 
     Map<String, Object> documentToMap(Document document) {

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentToSourceRecord.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/mappers/DocumentToSourceRecord.java
@@ -32,10 +32,10 @@ import com.ibm.cloud.cloudant.v1.model.Document;
 public class DocumentToSourceRecord implements BiFunction<String, ChangesResultItem, SourceRecord> {
 
     // Record key schema is {"_id": doc_id, "cloudant.url": url, "cloudant.db": db}
-    private static final Schema RECORD_KEY_SCHEMA = SchemaBuilder.struct()
+    public static final Schema RECORD_KEY_SCHEMA = SchemaBuilder.struct()
             .field(CloudantConst.CLOUDANT_DOC_ID, Schema.STRING_SCHEMA)
-            .field(InterfaceConst.URL, Schema.STRING_SCHEMA)
-            .field(InterfaceConst.DB, Schema.STRING_SCHEMA)
+            .field(InterfaceConst.DB, Schema.OPTIONAL_STRING_SCHEMA)
+            .field(InterfaceConst.URL, Schema.OPTIONAL_STRING_SCHEMA)
             .build();
     // Record value is Map<String, Object>
     // We can't use map(Schema.STRING_SCHEMA, null) as no schema (null) is not permitted for Kafka Connect's Map schema values.
@@ -88,8 +88,8 @@ public class DocumentToSourceRecord implements BiFunction<String, ChangesResultI
         RECORD_KEY_SCHEMA,
         new Struct(RECORD_KEY_SCHEMA)
                 .put(CloudantConst.CLOUDANT_DOC_ID, changesResultItem.getId())
-                .put(InterfaceConst.URL, partition.get(InterfaceConst.URL))
-                .put(InterfaceConst.DB, partition.get(InterfaceConst.DB)),
+                .put(InterfaceConst.DB, partition.get(InterfaceConst.DB))
+                .put(InterfaceConst.URL, partition.get(InterfaceConst.URL)),
                 RECORD_VALUE_SCHEMA,
         documentToMap(changesResultItem.getDoc()));
     }

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocument.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocument.java
@@ -14,15 +14,17 @@
 package com.ibm.cloud.cloudant.kafka.transforms.predicates;
 
 import java.util.Map;
+
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.transforms.predicates.Predicate;
 import org.apache.kafka.connect.transforms.util.Requirements;
 import com.ibm.cloud.cloudant.kafka.utils.MessageKey;
 import com.ibm.cloud.cloudant.kafka.utils.ResourceBundleUtil;
+
 import static com.ibm.cloud.cloudant.kafka.utils.CloudantConst.CLOUDANT_DESIGN_PREFIX;
 import static com.ibm.cloud.cloudant.kafka.utils.CloudantConst.CLOUDANT_DOC_ID;
 
@@ -45,14 +47,13 @@ public class IsDesignDocument implements Predicate<SourceRecord> {
     public boolean test(SourceRecord record) {
         Schema schema = record.keySchema();
         Object recordKey = record.key();
-        if (schema == null || recordKey == null || schema.type() != Type.MAP || schema.keySchema().type() != Type.STRING || schema.valueSchema().type() != Type.STRING) {
-            // Unexpected schema, check if the key is a map
-            // No need to use message file here, because this purpose gets inserted into the middle of an untranslated Kafka message
-            Requirements.requireMap(recordKey, "record key in IsDesignDocument predicate");
-            // If it is not a map this will throw
-        }
-        Map<String, String> key = (Map<String, String>) recordKey;
-        String id = key != null ? key.get(CLOUDANT_DOC_ID) : null;
+        // No need to use message file here, because this purpose gets inserted into the middle of an untranslated Kafka message
+        Requirements.requireSchema(schema, "record key in IsDesignDocument predicate");
+        Requirements.requireStruct(recordKey, "record key in IsDesignDocument predicate");
+        Struct key = (Struct) recordKey;
+        // will throw DataException if not valid
+        key.validate();
+        String id = key.getString(CLOUDANT_DOC_ID);
         if (id == null) {
             throw new DataException(String.format(ResourceBundleUtil.get(MessageKey.CLOUDANT_KEY_NO_ID), CLOUDANT_DOC_ID));
         } else {

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocument.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocument.java
@@ -54,11 +54,7 @@ public class IsDesignDocument implements Predicate<SourceRecord> {
         // will throw DataException if not valid
         key.validate();
         String id = key.getString(CLOUDANT_DOC_ID);
-        if (id == null) {
-            throw new DataException(String.format(ResourceBundleUtil.get(MessageKey.CLOUDANT_KEY_NO_ID), CLOUDANT_DOC_ID));
-        } else {
-            return id.startsWith(CLOUDANT_DESIGN_PREFIX);
-        }
+        return id.startsWith(CLOUDANT_DESIGN_PREFIX);
     }
 
     @Override

--- a/src/main/java/com/ibm/cloud/cloudant/kafka/utils/MessageKey.java
+++ b/src/main/java/com/ibm/cloud/cloudant/kafka/utils/MessageKey.java
@@ -71,6 +71,4 @@ public class MessageKey {
     public static final String CLOUDANT_STRUCT_UNHANDLED_TYPE = "CloudantStructUnhandledType";
     public static final String CLOUDANT_STRUCT_UNKNOWN_TYPE = "CloudantStructUnknownType";
 
-    public static final String CLOUDANT_KEY_NO_ID =	"CloudantKeyNoId";
-
 }

--- a/src/main/resources/message_en_US.properties
+++ b/src/main/resources/message_en_US.properties
@@ -73,5 +73,3 @@ CloudantStructUndetectableArrayType=Cannot infer array element type for arrays t
 CloudantStructMixedTypeArray=Cannot generate schemas for mixed type arrays, consider using the %s SMT.
 CloudantStructUnhandledType=Cannot transform schema type %s.
 CloudantStructUnknownType=Could not infer schema for class %s.
-
-CloudantKeyNoId=The record key does not have the required entry %s.

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/tasks/TombstoneTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/tasks/TombstoneTest.java
@@ -22,6 +22,7 @@ import com.ibm.cloud.cloudant.v1.model.ChangesResult;
 import com.ibm.cloud.cloudant.v1.model.ChangesResultItem;
 import com.ibm.cloud.cloudant.v1.model.Document;
 import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.junit.Assert;
@@ -102,8 +103,8 @@ public class TombstoneTest {
         Assert.assertEquals(2, records.size());
         Assert.assertNotNull(records.get(0).value());
         Assert.assertNull(records.get(1).value());
-        Assert.assertEquals(Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, id), records.get(0).key());
-        Assert.assertEquals(Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, id), records.get(1).key());
+        Assert.assertEquals(id, ((Struct)records.get(0).key()).get(CloudantConst.CLOUDANT_DOC_ID));
+        Assert.assertEquals(id, ((Struct)records.get(1).key()).get(CloudantConst.CLOUDANT_DOC_ID));
     }
 
 }

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocumentTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocumentTest.java
@@ -13,12 +13,13 @@
  */
 package com.ibm.cloud.cloudant.kafka.transforms.predicates;
 
+import static com.ibm.cloud.cloudant.kafka.mappers.DocumentToSourceRecord.RECORD_KEY_SCHEMA;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Test;
@@ -26,11 +27,7 @@ import com.ibm.cloud.cloudant.kafka.utils.CloudantConst;
 
 public class IsDesignDocumentTest {
 
-    // Record key schema is Map<String, String>
-    private static final Schema RECORD_KEY_SCHEMA = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build();
-
     IsDesignDocument isDDoc = new IsDesignDocument();
-
     private SourceRecord wrapInRecord(Schema keySchema, Object key) {
         return new SourceRecord(Collections.emptyMap(), Collections.emptyMap(), "test", keySchema, key, null, null);
     }
@@ -52,24 +49,24 @@ public class IsDesignDocumentTest {
 
     @Test(expected = DataException.class)
     public void testKeyNoId() {
-        isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, Collections.singletonMap("foo", "bar")));
+        isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, new Struct(RECORD_KEY_SCHEMA).put("foo", "bar")));
     }
 
     @Test
     public void testDesignDocument() {
         assertTrue("The design document should be filtered.",
-            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, "_design/foo"))));
+            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, new Struct(RECORD_KEY_SCHEMA).put(CloudantConst.CLOUDANT_DOC_ID, "_design/foo"))));
     }
 
     @Test
     public void testNearlyDesignDocument() {
         assertFalse("The document should not be filtered.",
-            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, "_designfoo"))));
+            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, new Struct(RECORD_KEY_SCHEMA).put(CloudantConst.CLOUDANT_DOC_ID, "_designfoo"))));
     }
 
     @Test
     public void testNotDesignDocument() {
         assertFalse("The document should not be filtered.",
-            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, Collections.singletonMap(CloudantConst.CLOUDANT_DOC_ID, "foo"))));
+            isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, new Struct(RECORD_KEY_SCHEMA).put(CloudantConst.CLOUDANT_DOC_ID, "foo"))));
     }
 }

--- a/src/test/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocumentTest.java
+++ b/src/test/java/com/ibm/cloud/cloudant/kafka/transforms/predicates/IsDesignDocumentTest.java
@@ -49,7 +49,8 @@ public class IsDesignDocumentTest {
 
     @Test(expected = DataException.class)
     public void testKeyNoId() {
-        isDDoc.test(wrapInRecord(RECORD_KEY_SCHEMA, new Struct(RECORD_KEY_SCHEMA).put("foo", "bar")));
+        // Struct.put will throw exception, no need to call isDDoc.test()
+        new Struct(RECORD_KEY_SCHEMA).put("foo", "bar");
     }
 
     @Test


### PR DESCRIPTION
fixes #135

testing showing new key output:
```sh
./bin/kafka-console-consumer.sh  --topic kafka_test_topic --bootstrap-server localhost:9092  --from-beginning --property print.key=true
...
{"_id":"4826c5d0c7c9eba0babc7a17699405af","cloudant.url":"https://740f610a-33d2-40bd-8f6b-2d4ef06c2140-bluemix.cloudantnosqldb.appdomain.cloud","cloudant.db":"cloudant_source_kafka_test_db"}	{"_rev":"1-967a00dff5e02add41819138abb3284d","_id":"4826c5d0c7c9eba0babc7a17699405af"}
```