### PR TITLE
build: package as zip instead of jar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,8 @@
 def prefixlessTag(tag) {
     return tag.replaceFirst('v','')
 }
-def jarUploadUrl
-def jarName
+def zipUploadUrl
+def zipName
 def ascUploadUrl
 def ascName
 
@@ -86,21 +86,21 @@ pipeline {
                             validResponseCodes: '201',
                             wrapAsMultipart: false
                 script {
-                    jarName = "cloudant-kafka-connector-${prefixlessTag(TAG_NAME)}.jar"
-                    ascName = "${jarName}.asc"
+                    zipName = "cloudant-kafka-connector-${prefixlessTag(TAG_NAME)}.zip"
+                    ascName = "${zipName}.asc"
                     // Process the release response to get the asset upload_url
                     def responseJson = readJSON file: 'release_response.json'
                     // Replace the path parameter template with a name
-                    jarUploadUrl = responseJson.upload_url.replace('{?name,label}',"?name=${jarName}")
+                    zipUploadUrl = responseJson.upload_url.replace('{?name,label}',"?name=${zipName}")
                     ascUploadUrl = responseJson.upload_url.replace('{?name,label}',"?name=${ascName}")
                 }
                 // Upload the asset to the release
                 httpRequest authentication: 'gh-sdks-automation',
-                            customHeaders: [[name: 'Accept', value: 'application/vnd.github+json'],[name: 'Content-Type', value: 'application/java-archive']],
+                            customHeaders: [[name: 'Accept', value: 'application/vnd.github+json'],[name: 'Content-Type', value: 'application/zip']],
                             httpMode: 'POST',
                             timeout: 60,
-                            uploadFile: "build/libs/${jarName}",
-                            url: jarUploadUrl,
+                            uploadFile: "build/distributions/${zipName}",
+                            url: zipUploadUrl,
                             validResponseCodes: '201',
                             wrapAsMultipart: false
                 // Upload the sig to the release
@@ -108,7 +108,7 @@ pipeline {
                             customHeaders: [[name: 'Accept', value: 'application/vnd.github+json'],[name: 'Content-Type', value: 'application/pgp-signature']],
                             httpMode: 'POST',
                             timeout: 60,
-                            uploadFile: "build/libs/${ascName}",
+                            uploadFile: "build/distributions/${ascName}",
                             url: ascUploadUrl,
                             validResponseCodes: '201',
                             wrapAsMultipart: false

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'distribution'
 apply plugin: 'java'
 apply plugin: 'signing'
 
@@ -95,17 +96,27 @@ jar.dependsOn generateClientPropertiesFile
 
 // modify the jar task to pull in required dependencies and add the client properties file
 jar {
-    duplicatesStrategy(duplicatesStrategy.EXCLUDE)
     into "META-INF", { 
         from generateClientPropertiesFile.clientPropsPath
         from 'LICENSE'
     }
-    from {
-        configurations.bundledImplementation.collect {
-            it.isDirectory() ? it : zipTree(it)
+}
+
+distributions {
+    main {
+        contents {
+            from 'README.md'
+            from 'LICENSE'
+            from('docs') {
+                into 'docs'
+            }
+            from configurations.bundledImplementation
+            from jar
         }
     }
 }
+// Produce only a zip
+distTar.enabled = false
 
 test {
     // Exclude the performance tests
@@ -136,6 +147,6 @@ tasks.withType(Sign) {
 }
 
 signing {
-    // When signing, sign the jar
-    sign jar
+    // When signing, sign the distribution zip
+    sign distZip
 }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes - build changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes - build changes, will document in release notes.
- [x] Completed the PR template below:

## Description

Package as a zip instead of an "uber jar".

## Approach

The "uber jar" failed to include all content from bundled dependencies because of path clashes. It is better to packge a directory so the dependencies can remain in their own jars.

This is achieved by using the gradle `distribution` plugin and creating a zip file.

## Schema & API Changes

- Change in installation method.

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes, but did verify new output content, signature and function.

## Monitoring and Logging

- "No change"
