### PR TITLE
docs: remove release process from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,3 @@ INFO level logging is configured by default to the console. To change log levels
 and add log settings like
 
 `log4j.logger.com.ibm.cloud.cloudant.kafka=DEBUG, stdout`
-
-## Release Process
-
-For developers, the release process can be found [here](docs/releasing.md)


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Release instructions were removed in #173, but a reference to that document was left in the README.


## Approach

This PR removes the section with the reference to the release doc from the readme.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging
- "No change"
